### PR TITLE
Missing error message when credentials are wrong #3

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "scripts": {
     "build": "grafana-toolkit plugin:build",
-    "dev": "grafana-toolkit plugin:dev",
+    "dev": "grafana-toolkit plugin:dev -w",
     "test": "grafana-toolkit plugin:test",
     "test:coverage": "yarn test --coverage",
     "test:badges": "yarn test:coverage && jest-coverage-badges"

--- a/src/components/device_details.ts
+++ b/src/components/device_details.ts
@@ -12,7 +12,7 @@ export class DeviceDetailsCtrl {
   region = '';
 
   /** @ngInject */
-  constructor($scope, $injector, public $location: any, public backendSrv: any, public alertSrv: any) {
+  constructor($scope, $injector, $http, public $location: any, public backendSrv: any, public alertSrv: any) {
     this.device = {};
     this.deviceDTO = {};
     this.pageReady = false;
@@ -20,7 +20,7 @@ export class DeviceDetailsCtrl {
     //this.region = "default";
     backendSrv.get('/api/datasources').then((allDS: any) => {
       this.region = getRegion(allDS);
-      this.kentik = new KentikAPI(this.backendSrv);
+      this.kentik = new KentikAPI(this.backendSrv, $http);
       this.kentik.setRegion(this.region);
       this.getDevice($location.search().device);
     });

--- a/src/components/device_list.ts
+++ b/src/components/device_list.ts
@@ -9,23 +9,17 @@ class DeviceListCtrl {
   kentik: KentikAPI;
 
   /** @ngInject */
-  constructor(private $scope, $injector, public $location: any, public backendSrv: any) {
+  constructor(private $scope, $injector, $http, public $location: any, public backendSrv: any) {
     this.devices = [];
     this.pageReady = false;
-    this.kentik = new KentikAPI(this.backendSrv);
+    this.kentik = new KentikAPI(this.backendSrv, $http);
     this.getDevices();
   }
 
-  getDevices() {
-    try {
-      this.kentik.getDevices().then(devices => {
-        this.devices = devices;
-        this.pageReady = true;
-        this.$scope.$apply();
-      });
-    } catch (e) {
-      showAlert(e);
-    }
+  async getDevices() {
+    this.devices = await this.kentik.getDevices();
+    this.pageReady = true;
+    this.$scope.$apply();
   }
 
   refresh() {

--- a/src/config/config.html
+++ b/src/config/config.html
@@ -41,7 +41,7 @@
       <div ng-if="ctrl.appModel.jsonData.tokenSet" class="gf-form">
         <input type="text" class="gf-form-input max-width-20" disabled="disabled" value="saved" />
         <div ng-if="ctrl.appModel.enabled">
-          <i class="fa fa-exclamation-triangle" ng-if="!ctrl.apiValidated" alt="Could not validate api Token."></i>
+          <i class="fa fa-exclamation-triangle" ng-if="ctrl.apiError" bs-tooltip="'Could not validate api Token.'"></i>
         </div>
       </div>
     </div>
@@ -51,7 +51,7 @@
   </div>
 </div>
 
-<div ng-if="ctrl.appModel.jsonData.tokenSet" class="kentik-enabled-box">
+<div ng-if="ctrl.appModel.jsonData.tokenSet && ctrl.apiValidated" class="kentik-enabled-box">
   <i class="icon-gf icon-gf-check icon-gf-check kentik-icon-success"></i> Successfully enabled. <strong>Next up:
   </strong><a href="dashboard/db/kentik-home" class="external-link">Go to Kentik Home Dashboard</a>
 </div>

--- a/src/datasource/datasource.test.ts
+++ b/src/datasource/datasource.test.ts
@@ -59,8 +59,14 @@ function createDatasourceInstance(ctx, data) {
       });
     },
   };
+  ctx.$http = () => {
+    return Promise.resolve({
+      status: 200,
+      data,
+    });
+  };
 
-  ctx.kentikAPI = new KentikAPI(ctx.backendSrv);
+  ctx.kentikAPI = new KentikAPI(ctx.backendSrv, ctx.$http);
   ctx.kentikAPI.setRegion('default');
 
   ctx.kentikProxy = new KentikProxy({}, ctx.kentikAPI);

--- a/src/datasource/kentikAPI.ts
+++ b/src/datasource/kentikAPI.ts
@@ -81,9 +81,13 @@ export class KentikAPI {
       });
 
       return resp;
-    } catch (e) {
-      showAlert(e);
-      throw e;
+    } catch (error) {
+      showAlert(error);
+      if (error.err) {
+        throw error.err;
+      } else {
+        throw error;
+      }
     }
   }
 
@@ -105,7 +109,7 @@ export class KentikAPI {
         return [];
       }
     } catch(error) {
-      console.error(error);
+      showAlert(error);
       if (error.err) {
         throw error.err;
       } else {

--- a/src/datasource/kentikProxy.test.ts
+++ b/src/datasource/kentikProxy.test.ts
@@ -59,8 +59,14 @@ function getKentikProxyInstance(ctx, data) {
       });
     },
   };
+  ctx.$http = () => {
+    return Promise.resolve({
+      status: 200,
+      data,
+    });
+  };
 
-  ctx.kentikAPI = new KentikAPI(ctx.backendSrv);
+  ctx.kentikAPI = new KentikAPI(ctx.backendSrv, ctx.$http);
   ctx.kentikAPI.setRegion('default');
   ctx.kentikProxy = new KentikProxy({}, ctx.kentikAPI);
 }

--- a/src/panel/call-to-action/module.ts
+++ b/src/panel/call-to-action/module.ts
@@ -22,7 +22,7 @@ class CallToActiontCtrl extends PanelCtrl {
   region = '';
 
   /** @ngInject */
-  constructor($scope, $injector, public backendSrv: any, private datasourceSrv) {
+  constructor($scope, $injector, $http, public backendSrv: any, private datasourceSrv) {
     super($scope, $injector);
     _.defaults(this.panel, panelDefaults);
     this.deviceStatus = '';
@@ -33,7 +33,7 @@ class CallToActiontCtrl extends PanelCtrl {
       .get('/api/datasources')
       .then((allDS: any) => {
         this.region = getRegion(allDS);
-        this.kentik = new KentikAPI(this.backendSrv);
+        this.kentik = new KentikAPI(this.backendSrv, $http);
         this.kentik.setRegion(this.region);
       })
       .then(async () => {

--- a/src/panel/device-list/module.ts
+++ b/src/panel/device-list/module.ts
@@ -24,7 +24,7 @@ class DeviceListCtrl extends PanelCtrl {
   region = '';
 
   /** @ngInject */
-  constructor($scope, $injector, public $location: any, public backendSrv: any) {
+  constructor($scope, $injector, $http, public $location: any, public backendSrv: any) {
     super($scope, $injector);
     _.defaults(this.panel, panelDefaults);
     this.devices = [];
@@ -35,7 +35,7 @@ class DeviceListCtrl extends PanelCtrl {
       .get('/api/datasources')
       .then((allDS: any) => {
         this.region = getRegion(allDS);
-        this.kentik = new KentikAPI(this.backendSrv);
+        this.kentik = new KentikAPI(this.backendSrv, $http);
         this.kentik.setRegion(this.region);
       })
       .then(async () => {


### PR DESCRIPTION
Fixes #3

The problem is that `datasourceRequest()` displays `Unexpected error` alert and returns `undefined` on any request error. Although we expect it to throw an error.

## Changes
- use `$http()` instead of `datasourceRequest()`
- fix tests
- watch mode for `npm run dev`