### PR TITLE
Resolve IPs in a given view #5

### DIFF
--- a/src/dashboards/kentik-top-talkers.json
+++ b/src/dashboards/kentik-top-talkers.json
@@ -60,7 +60,8 @@
               "mode": "graph",
               "refId": "A",
               "target": "",
-              "unit": "$unit"
+              "unit": "$unit",
+              "hostnameLookup": "$dns_lookup"
             }
           ],
           "timeFrom": null,
@@ -142,7 +143,8 @@
               "mode": "table",
               "refId": "A",
               "target": "",
-              "unit": "$unit"
+              "unit": "$unit",
+              "hostnameLookup": "$dns_lookup"
             }
           ],
           "title": "",
@@ -181,6 +183,34 @@
   },
   "templating": {
     "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "disable",
+          "value": "disable"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "DNS Lookup",
+        "multi": false,
+        "name": "dns_lookup",
+        "options": [
+          {
+            "selected": false,
+            "text": "enabled",
+            "value": "enabled"
+          },
+          {
+            "selected": true,
+            "text": "disabled",
+            "value": "disabled"
+          }
+        ],
+        "query": "enable,disable",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
       {
         "current": {
           "tags": [],

--- a/src/datasource/datasource.ts
+++ b/src/datasource/datasource.ts
@@ -52,6 +52,7 @@ class KentikDatasource {
       unit: this.templateSrv.replace(target.unit),
       kentikFilterGroups: kentikFilterGroups.kentikFilters,
       kentikSavedFilters: kentikFilterGroups.savedFilters,
+      hostnameLookup: this.templateSrv.replace(target.hostnameLookup),
     };
     const query = queryBuilder.buildTopXdataQuery(queryOptions);
 

--- a/src/datasource/query_builder.ts
+++ b/src/datasource/query_builder.ts
@@ -119,6 +119,7 @@ function buildTopXdataQuery(options) {
     aggregates: formatAggs(unitDef),
     filters_obj: formatFilters(options.kentikFilterGroups),
     saved_filters: options.kentikSavedFilters,
+    hostname_lookup: options.hostnameLookup,
   };
 
   return query;

--- a/src/datasource/query_editor.html
+++ b/src/datasource/query_editor.html
@@ -42,4 +42,18 @@
       <div class="gf-form-label gf-form-label--grow"></div>
     </div>
   </div>
+  <div class="gf-form-inline">
+    <div class="gf-form">
+        <label class="gf-form-label width-7">DNS Lookup</label>
+        <metric-segment
+          class="width-11"
+          segment="ctrl.hostnameLookup"
+          get-options="ctrl.getHostnameLookupOptionValues()"
+          on-change="ctrl.onHostnameLookupChange()"
+        ></metric-segment>
+    </div>
+    <div class="gf-form gf-form--grow">
+        <div class="gf-form-label gf-form-label--grow"></div>
+      </div>
+  </div>
 </query-editor-row>


### PR DESCRIPTION
Closes #5

## Changes
- optional DNS lookup for metrics in panels


- template variable for enabling / disabling DNS Lookup
![image](https://user-images.githubusercontent.com/1989898/65885255-fc620480-e3a2-11e9-90b6-f7f4337ab609.png)


- panel-editor option for enabling / disabling DNS Lookup. Can be used to override dashboard settings.
![image](https://user-images.githubusercontent.com/1989898/65885265-0257e580-e3a3-11e9-8c2f-c73a162fb534.png)


**Please note: dashboard should be re-imported to use "DNS Lookup" template variable.**

Configuration -> Plugins -> Kentik Connect Pro -> Dashboards -> Kentik Top Talkers -> Re-import