### PR TITLE
Use webpack instead of grafana-toolkit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,254 +2,107 @@ version: 2
 
 aliases:
   # Workflow filters
+  - &filter-only-release
+    branches:
+      ignore: /.*/
+    tags:
+      only: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+  - &filter-not-release-or-master
+    tags:
+      ignore: /^v[0-9]+(\.[0-9]+){2}(-.+|[^-.]*)$/
+    branches:
+      ignore: master
   - &filter-only-master
     branches:
       only: master
 
-jobs:
-  build_plugin:
-    docker:
-    - image: circleci/node:10
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Install yarn
-        command: |
-          sudo npm install -g yarn --quiet
-          yarn install --pure-lockfile
-    - run:
-        name: Run Toolkit Build
-        command: npx grafana-toolkit plugin:ci-build
-    - save_cache:
-        paths:
-        - node_modules
-        key: yarn-packages-{{ checksum "yarn.lock" }}
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci
-  build_docs:
-    docker:
-    - image: circleci/node:10
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Install yarn
-        command: |
-          sudo npm install -g yarn --quiet
-          yarn install --pure-lockfile
-          mkdir ci # Avoid error if not exists
-    - run:
-        name: Build Docs
-        command: npx grafana-toolkit plugin:ci-docs
-    - save_cache:
-        paths:
-        - node_modules
-        key: yarn-packages-{{ checksum "yarn.lock" }}
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci
-  build_osx:
-    docker:
-    - image: circleci/node:10
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Install yarn
-        command: |
-          sudo npm install -g yarn --quiet
-          yarn install --pure-lockfile
-    - run:
-        name: Run Toolkit CI
-        command: npx grafana-toolkit plugin:ci-build --backend osx
-    - save_cache:
-        paths:
-        - node_modules
-        key: yarn-packages-{{ checksum "yarn.lock" }}
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci/jobs/build_osx
-  build_win64:
-    docker:
-    - image: circleci/node:10
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Install yarn
-        command: |
-          sudo npm install -g yarn --quiet
-          yarn install --pure-lockfile
-    - run:
-        name: Run Toolkit CI
-        command: npx grafana-toolkit plugin:ci-build --backend win64
-    - save_cache:
-        paths:
-        - node_modules
-        key: yarn-packages-{{ checksum "yarn.lock" }}
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci/jobs/build_win64
-  package:
-    docker:
-    - image: circleci/node:10
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Package Distribution
-        command: npx grafana-toolkit plugin:ci-package
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci/jobs/package
-        - ci/packages
-        - ci/dist
-        - ci/grafana-test-env
-  test_6_3_2:
-    docker:
-    - image: circleci/node:10-browsers
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Setup Grafana (local install)
-        command: |
-          wget https://dl.grafana.com/oss/release/grafana_6.3.2_amd64.deb
-          sudo apt-get install -y adduser libfontconfig1
-          sudo dpkg -i grafana_6.3.2_amd64.deb
-          sudo apt-get install locate
-          sudo updatedb
-          sudo locate grafana
-          sudo cat /etc/grafana/grafana.ini
-          sudo echo ------------------------
-          sudo cp ci/grafana-test-env/custom.ini /usr/share/grafana/conf/custom.ini
-          sudo cp ci/grafana-test-env/custom.ini /etc/grafana/grafana.ini
-          sudo service grafana-server start
-          sudo grafana-cli --version
-    - run:
-        name: Run e2e tests
-        command: |
-          npx grafana-toolkit plugin:ci-test
-    - persist_to_workspace:
-        root: .
-        paths:
-        - ci/jobs/test_6_3_2
-    - store_test_results:
-        path: ci/jobs/test_6_3_2
-    - store_artifacts:
-        path: ci/jobs/test_6_3_2
-  report:
-    docker:
-    - image: circleci/node:10
-    working_directory: ~/plugin
-    steps:
-    - checkout
-    - attach_workspace:
-        at: .
-    - restore_cache:
-        keys:
-        - yarn-packages-{{ checksum "yarn.lock" }}
-    - run:
-        name: Toolkit Report
-        command: npx grafana-toolkit plugin:ci-report
-    - store_artifacts:
-        path: ci
+defaults: &defaults
+  working_directory: ~/kentik-app
+  docker:
+    - image: circleci/node:10.15.3-stretch
 
-  publish_github_release:
-    working_directory: ~/kentik-app
-    docker:
-      - image: cibuilds/github:0.12
+jobs:
+  build:
+    <<: *defaults
     steps:
       - checkout
-      - add_ssh_keys:
-          fingerprints:
-            - "1a:0f:43:a8:9f:89:ad:ef:06:b0:94:ba:86:09:e5:29"
-      - attach_workspace:
-          at: .
+      - restore_cache:
+          keys:
+            - v1-npm-deps-{{ checksum "package-lock.json" }}
       - run:
-          name: "Publish Release on GitHub"
+          name: Build
           command: |
             PLUGIN_NAME=kentik-app
-            apk add --update --no-cache jq
-            RELEASE_NOTES=`awk 'BEGIN {FS="##"; RS=""} FNR==3 {print; exit}' CHANGELOG.md`
+            npm install
+            npm run build
+            sudo apt-get install jq
             VERSION=`cat src/plugin.json|jq '.info.version'| sed s/\"//g`
-            ls -al
-            ls -al ./artifacts
-            git config user.email "eng@grafana.com"
-            git config user.name "CircleCI Automation"
-            git checkout -b release-${VERSION}
-            git add --force dist/
-            git add artifacts/
-            git commit -m "automated release $VERSION [skip ci]"
-            git push -f origin release-${VERSION}
-            git tag -f v${VERSION}
-            git push -f origin v${VERSION}
-            ghr \
-              -t ${GITHUB_TOKEN} \
-              -u ${CIRCLE_PROJECT_USERNAME} \
-              -r ${CIRCLE_PROJECT_REPONAME} \
-              -c ${CIRCLE_SHA1} \
-              -n "${PLUGIN_NAME} v${VERSION}" \
-              -b "${RELEASE_NOTES}" \
-              -delete \
-              v${VERSION} \
-              ./artifacts/
+            # create zip file
+            cd ~
+            echo "Creating ZIP"
+            zip \
+              -x ${PLUGIN_NAME}/.git/**\* \
+              -x ${PLUGIN_NAME}/node_modules/**\* \
+              -r /tmp/${PLUGIN_NAME}-${VERSION}.zip \
+              ${PLUGIN_NAME}
+            # create tar file
+            echo "Creating TAR"
+            tar \
+              --exclude .git \
+              --exclude ${PLUGIN_NAME}/node_modules \
+              -cvf /tmp/${PLUGIN_NAME}-${VERSION}.tar \
+              ${PLUGIN_NAME}
+            gzip /tmp/${PLUGIN_NAME}-${VERSION}.tar
+            # create artifacts
+            mkdir -p ~/${PLUGIN_NAME}/artifacts
+            mv /tmp/${PLUGIN_NAME}-${VERSION}.zip ~/${PLUGIN_NAME}/artifacts/
+            mv /tmp/${PLUGIN_NAME}-${VERSION}.tar.gz ~/${PLUGIN_NAME}/artifacts/
+          no_output_timeout: 5m
+      - save_cache:
+          name: Save NPM Package Cache
+          key: v1-npm-deps-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/.cache/npm
+      - persist_to_workspace:
+          root: .
+          paths:
+            - artifacts
+            - dist
+      - store_artifacts:
+          path: artifacts
+      - store_artifacts:
+          path: dist
+
+  test:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-npm-deps-{{ checksum "package-lock.json" }}
+      - run:
+          name: Test
+          command: |
+            npm install
+            sudo npm install -g jest
+            npm test
 
 workflows:
   version: 2
-  plugin_workflow:
+  build-master:
     jobs:
-    - build_plugin
-    - build_osx
-    - build_win64
-    - build_docs
-    - package:
-        requires:
-        - build_plugin
-        - build_osx
-        - build_win64
-        - build_docs
-    - test_6_3_2:
-        requires:
-        - package
-    - report:
-        requires:
-        - test_6_3_2
-    - approve_release:
-        type: approval
-        requires:
-          - report
-        filters: *filter-only-master
-    - publish_github_release:
-        requires:
-          - approve_release
-        filters: *filter-only-master
+      - build:
+          filters: *filter-only-master
+      - test:
+          requires:
+            - build
+          filters: *filter-only-master
+
+  build-branches-and-prs:
+    jobs:
+      - build:
+          filters: *filter-not-release-or-master
+      - test:
+          requires:
+            - build
+          filters: *filter-not-release-or-master

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  ...require("./node_modules/@grafana/toolkit/src/config/prettier.plugin.config.json"),
-};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ All notable changes to this project will be documented in this file.
 
 ## [1.3.5] - 2019-09-23
 
-Merge pull request #15 from kentik/autocomplete-for-plugin-#4
-
 Autocomplete for plugin #4
 
 ## [1.3.4] - 2019-05-24

--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -1,0 +1,127 @@
+const path = require('path');
+const webpack = require('webpack');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+
+const ngAnnotatePlugin = require('ng-annotate-webpack-plugin');
+const ReplaceInFileWebpackPlugin = require('replace-in-file-webpack-plugin');
+
+
+const NODE_MODULES_REG_EXP = /node_modules/;
+
+const ExtractTextPluginLight = new ExtractTextPlugin('./styles/light.css');
+const ExtractTextPluginDark = new ExtractTextPlugin('./styles/dark.css');
+
+function resolve(dir) {
+  return path.join(__dirname, '..', dir);
+}
+
+const packageJson = require('../package.json');
+
+module.exports = {
+  target: 'node',
+  context: resolve('src'),
+  entry: {
+    './module': './module.ts',
+    'datasource/module': './datasource/module.ts',
+    'panel/call-to-action/module': './panel/call-to-action/module.ts',
+    'panel/device-list/module': './panel/device-list/module.ts',
+  },
+  output: {
+    filename: '[name].js',
+    path: resolve('dist'),
+    libraryTarget: 'amd'
+  },
+  externals: [
+    // remove the line below if you don't want to use buildin versions
+    'jquery', 'lodash', 'moment', 'angular',
+    function (context, request, callback) {
+      var prefix = 'grafana/';
+      if (request.indexOf(prefix) === 0) {
+        return callback(null, request.substr(prefix.length));
+      }
+      callback();
+    }
+  ],
+  plugins: [
+    new webpack.optimize.OccurrenceOrderPlugin(),
+    new CopyWebpackPlugin([
+      { from: '../README.md' },
+      { from: '../CHANGELOG.md' },
+      { from: '**/plugin.json' },
+      { from: 'panel/**/*.html' },
+      { from: 'datasource/**/*.html' },
+      { from: 'components/**/*.html' },
+      { from: 'dashboards/*' },
+      { from: 'img/*' },
+    ]),
+
+    new ReplaceInFileWebpackPlugin([
+      {
+        dir: 'dist',
+        files: ['plugin.json'],
+        rules: [
+          {
+            search: '%VERSION%',
+            replace: packageJson.version,
+          },
+          {
+            search: '%TODAY%',
+            replace: new Date().toISOString().substring(0, 10),
+          },
+        ],
+      },
+    ]),
+
+    ExtractTextPluginLight,
+    ExtractTextPluginDark,
+
+    new CleanWebpackPlugin(['dist'], {
+      root: resolve('.')
+    }),
+    new ngAnnotatePlugin()
+  ],
+  resolve: {
+    extensions: ['.js', '.ts', '.html', '.scss'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: [NODE_MODULES_REG_EXP],
+        loaders: [
+          'ts-loader'
+        ],
+      },
+      {
+        test: /\.html$/,
+        exclude: [NODE_MODULES_REG_EXP],
+        use: {
+          loader: 'html-loader'
+        },
+      },
+      {
+        test: /\.scss$/,
+        exclude: [NODE_MODULES_REG_EXP, /dark\.scss/, /light\.scss/],
+        use: ['style-loader', 'css-loader', 'sass-loader']
+      },
+      {
+        test: /light\.scss$/,
+        exclude: [NODE_MODULES_REG_EXP],
+        use: ExtractTextPluginLight.extract({
+          fallback: 'style-loader',
+          use: ['css-loader', 'sass-loader']
+        }),
+      },
+      {
+        test: /dark\.scss$/,
+        exclude: [NODE_MODULES_REG_EXP],
+        use: ExtractTextPluginDark.extract({
+          fallback: 'style-loader',
+          use: ['css-loader', 'sass-loader']
+        }),
+      }
+    ]
+  }
+}

--- a/build/webpack.dev.conf.js
+++ b/build/webpack.dev.conf.js
@@ -1,0 +1,12 @@
+const baseWebpackConfig = require('./webpack.base.conf');
+
+var conf = baseWebpackConfig;
+conf.watch = true;
+conf.watchOptions = {
+  poll: 1000,
+  ignored: ['src/**/*.js', 'node_modules']
+};
+conf.mode = 'development';
+conf.devtool = 'inline-source-map';
+
+module.exports = baseWebpackConfig;

--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -1,0 +1,6 @@
+const baseWebpackConfig = require('./webpack.base.conf');
+
+var conf = baseWebpackConfig;
+conf.mode = 'production';
+
+module.exports = baseWebpackConfig;

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  verbose: true,
+  globals: {
+    'ts-jest': {
+      tsConfig: 'tsconfig.jest.json'
+    }
+  },
+  transform: {
+    '\\.ts': 'ts-jest'
+  },
+  testRegex: '(\\.|/)([jt]est)\\.[jt]s$',
+  moduleFileExtensions: [
+    'ts',
+    'js',
+    'json'
+  ],
+  setupFiles: [
+    '<rootDir>/setup_tests.ts'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -4,11 +4,9 @@
   "version": "1.3.6",
   "description": "",
   "scripts": {
-    "build": "grafana-toolkit plugin:build",
-    "dev": "grafana-toolkit plugin:dev -w",
-    "test": "grafana-toolkit plugin:test",
-    "test:coverage": "yarn test --coverage",
-    "test:badges": "yarn test:coverage && jest-coverage-badges"
+    "build": "webpack --config build/webpack.prod.conf.js",
+    "dev": "webpack --config build/webpack.dev.conf.js",
+    "test": "jest --config jest.config.js"
   },
   "repository": {
     "type": "git",
@@ -19,16 +17,30 @@
   "bugs": {
     "url": "https://github.com/grafana/kentik-app/issues"
   },
-  "dependencies": {
-    "jquery": "^3.4.1",
-    "lodash": "^4.17.15",
-    "moment": "^2.24.0"
-  },
   "devDependencies": {
+    "@babel/core": "7.4.5",
     "@grafana/toolkit": "6.3.2",
-    "@grafana/ui": "6.3.2",
     "@types/angular": "1.6.54",
-    "@types/grafana": "github:CorpGlory/types-grafana.git",
-    "angular": "1.6.6"
-  }
+    "@types/grafana": "github:CorpGlory/types-grafana",
+    "@types/jest": "23.3.14",
+    "clean-webpack-plugin": "0.1.19",
+    "copy-webpack-plugin": "4.6.0",
+    "css-loader": "1.0.1",
+    "extract-text-webpack-plugin": "4.0.0-beta.0",
+    "html-loader": "0.5.5",
+    "jest": "23.6.0",
+    "lodash": "^4.17.15",
+    "moment": "2.24.0",
+    "ng-annotate-webpack-plugin": "0.3.0",
+    "node-sass": "4.12.0",
+    "replace-in-file-webpack-plugin": "^1.0.6",
+    "sass-loader": "7.1.0",
+    "style-loader": "0.23.1",
+    "ts-jest": "23.10.5",
+    "ts-loader": "5.4.5",
+    "typescript": "3.4.5",
+    "webpack": "4.32.2",
+    "webpack-cli": "3.3.2"
+  },
+  "dependencies": {}
 }

--- a/setup_tests.ts
+++ b/setup_tests.ts
@@ -1,0 +1,2 @@
+console.log = jest.fn();
+console.error = jest.fn();

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,6 @@
+import './styles/dark.scss';
+import './styles/light.scss';
+
 import { ConfigCtrl } from './config/config';
 import { DeviceListCtrl } from './components/device_list';
 import { DeviceDetailsCtrl } from './components/device_details';

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,3 @@
+{
+  "extends": "./tsconfig"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,21 @@
 {
-  "extends": "./node_modules/@grafana/toolkit/src/config/tsconfig.plugin.json",
-  "include": ["src", "types"],
   "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es5",
+    "lib": [
+      "es6",
+      "dom"
+    ],
     "rootDir": "./src",
-    "typeRoots": ["./node_modules/@types"],
-
+    "declaration": false,
     "allowSyntheticDefaultImports": true,
-    "noImplicitReturns": false,
-    "noImplicitThis": false,
-    "noImplicitUseStrict": false,
+    "inlineSourceMap": false,
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
     "noImplicitAny": false,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "baseUrl": "./src"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "inlineSourceMap": false,
     "sourceMap": true,
-    "noEmitOnError": true,
+    "noEmitOnError": false,
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
       "es6",
       "dom"
     ],
+    "module": "esnext",
     "rootDir": "./src",
     "declaration": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
closes #11 

[@grafana/toolkit](https://www.npmjs.com/package/@grafana/toolkit) is a convenient way to build plugins but it's not flexible. For example:
- there is no way to customize build process (change webpack configs)
- there is no way to customize testing process (only [a few jest config properties](https://www.npmjs.com/package/@grafana/toolkit#can-i-provide-custom-setup-for-jest) are available)
- there is no way to [change tslint config](https://www.npmjs.com/package/@grafana/toolkit#can-i-adjust-tslint-configuration-to-suit-my-needs)
- etc

## Changes
- add webpack configs to build
- add packages necessary for building to `package.json`
- add `tsconfig.json`
- add jest configs
- fix CircleCI config