### PR TITLE
Fix 403 error when using non-admin Kentik user #31

### DIFF
--- a/src/config/config.html
+++ b/src/config/config.html
@@ -52,6 +52,14 @@
 </div>
 
 <div ng-if="ctrl.appModel.jsonData.tokenSet && ctrl.apiValidated" class="kentik-enabled-box">
-  <i class="icon-gf icon-gf-check icon-gf-check kentik-icon-success"></i> Successfully enabled. <strong>Next up:
-  </strong><a href="dashboard/db/kentik-home" class="external-link">Go to Kentik Home Dashboard</a>
+  <i class="icon-gf icon-gf-check kentik-api-status-icon success"></i>
+  Successfully enabled.
+  <strong>Next up: </strong>
+  <a href="dashboard/db/kentik-home" class="external-link">Go to Kentik Home Dashboard</a>
+</div>
+
+<div ng-if="ctrl.appModel.jsonData.tokenSet && ctrl.apiValidated && ctrl.apiMemberWarning" class="kentik-enabled-box">
+  <i class="fa fa-warning kentik-api-status-icon warning"></i>
+  The specified Kentik user seems to have Member access level (not Admin),
+  Custom Dimensions in the dashboard filters won't be available.
 </div>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,7 +1,7 @@
 import configTemplate from './config.html';
 
 import { KentikAPI } from '../datasource/kentik_api';
-import { showAlert, showCustomAlert } from '../datasource/alert_helper';
+import { showCustomAlert } from '../datasource/alert_helper';
 
 import { BackendSrv } from 'grafana/app/core/services/backend_srv';
 
@@ -15,12 +15,15 @@ enum Region {
 }
 
 class KentikConfigCtrl {
+  static template: any;
+
   apiValidated = false;
   apiError = false;
+  apiMemberWarning = false;
+
   appEditCtrl: any;
   appModel: any;
   kentik: KentikAPI;
-  static template: any;
   regionTypes = [
     { value: Region.DEFAULT, text: 'US (default)' },
     { value: Region.EU, text: 'EU' },
@@ -69,23 +72,31 @@ class KentikConfigCtrl {
   }
 
   // make sure that we can hit the Kentik API.
-  async validateApiConnection() {
+  async validateApiConnection(): Promise<void> {
+    // any user (Admin / Member) can get devices
     try {
-      const result = await this.kentik.getUsers();
-      try {
-        if (result.hasOwnProperty('data')) {
-          this.apiValidated = true;
-          showCustomAlert('API working!', '', 'success');
-        }
-      } catch (e) {
-        showAlert('Unexpected result from API: ' + e);
-        this.apiValidated = false;
-        this.apiError = true;
-      }
+      await this.kentik.getDevices();
     } catch (e) {
       this.apiValidated = false;
       this.apiError = true;
+      return;
     }
+
+    // only Admin can get users list
+    try {
+      await this.kentik.getUsers();
+    } catch (e) {
+      if (e.status !== 403) {
+        this.apiValidated = false;
+        this.apiError = true;
+        return;
+      }
+
+      this.apiMemberWarning = true;
+    }
+
+    this.apiValidated = true;
+    showCustomAlert('API working!', '', 'success');
     this.$scope.$digest();
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -77,8 +77,7 @@ class KentikConfigCtrl {
     try {
       await this.kentik.getDevices();
     } catch (e) {
-      this.apiValidated = false;
-      this.apiError = true;
+      this._onApiError();
       return;
     }
 
@@ -87,8 +86,7 @@ class KentikConfigCtrl {
       await this.kentik.getUsers();
     } catch (e) {
       if (e.status !== 403) {
-        this.apiValidated = false;
-        this.apiError = true;
+        this._onApiError();
         return;
       }
 
@@ -149,6 +147,12 @@ class KentikConfigCtrl {
       }
     }
     return promisesResults;
+  }
+
+  private _onApiError(): void {
+    this.apiValidated = false;
+    this.apiError = true;
+    this.$scope.$digest();
   }
 
   private _getUrlByRegion(region: Region): string {

--- a/src/datasource/kentik_api.ts
+++ b/src/datasource/kentik_api.ts
@@ -24,7 +24,8 @@ export class KentikAPI {
   }
 
   async getUsers(): Promise<any> {
-    return this._get('/api/v5/users');
+    const requiresAdminLevel = true;
+    return this._get('/api/v5/users', requiresAdminLevel);
   }
 
   async getFieldValues(field: string): Promise<any> {
@@ -34,8 +35,8 @@ export class KentikAPI {
 
   async getCustomDimensions(): Promise<any[]> {
     try {
-      const silent = true;
-      const resp = await this._get('/api/v5/customdimensions', silent);
+      const requiresAdminLevel = true;
+      const resp = await this._get('/api/v5/customdimensions', requiresAdminLevel);
       return resp.data.customDimensions;
     } catch (e) {
       if (e.status === 403) {
@@ -66,7 +67,7 @@ export class KentikAPI {
     return this._post('/api/v5/query/sql', data);
   }
 
-  private async _get(url: string, silent = false): Promise<any> {
+  private async _get(url: string, requiresAdminLevel = false): Promise<any> {
     try {
       const resp = await this.$http({
         method: 'GET',
@@ -75,7 +76,7 @@ export class KentikAPI {
 
       return resp;
     } catch (error) {
-      if (silent === false) {
+      if (error.status !== 403 || requiresAdminLevel === false) {
         showAlert(error);
       }
       if (error.err) {

--- a/src/datasource/kentik_api.ts
+++ b/src/datasource/kentik_api.ts
@@ -32,9 +32,17 @@ export class KentikAPI {
     return this.invokeSQLQuery(query);
   }
 
-  async getCustomDimensions(): Promise<any> {
-    const data = await this._get('/api/v5/customdimensions');
-    return data.data.customDimensions;
+  async getCustomDimensions(): Promise<any[]> {
+    try {
+      const silent = true;
+      const resp = await this._get('/api/v5/customdimensions', silent);
+      return resp.data.customDimensions;
+    } catch (e) {
+      if (e.status === 403) {
+        return [];
+      }
+      throw e;
+    }
   }
 
   async getSavedFilters(): Promise<any> {
@@ -58,7 +66,7 @@ export class KentikAPI {
     return this._post('/api/v5/query/sql', data);
   }
 
-  private async _get(url: string): Promise<any> {
+  private async _get(url: string, silent = false): Promise<any> {
     try {
       const resp = await this.$http({
         method: 'GET',
@@ -67,7 +75,9 @@ export class KentikAPI {
 
       return resp;
     } catch (error) {
-      showAlert(error);
+      if (silent === false) {
+        showAlert(error);
+      }
       if (error.err) {
         throw error.err;
       } else {

--- a/src/panel/call_to_action/module.html
+++ b/src/panel/call_to_action/module.html
@@ -5,21 +5,6 @@
   performance.</p>
 
 <div class="kentik-dash-flex-container">
-  <!-- disabled - (no code implements this)
-  <div class="kentik-dash-flex-item" ng-if="!ctrl.AllDone()">
-    <span class="kentik-dashboard-blurb">To do:</span>
-    <div ng-if="ctrl.endpointStatus === 'noEndpoints'" class="kentik-CTA-item">
-      <div class="kentik-dashboard-icons-container">
-        <i class="icon-gf icon-gf-endpoint kentik-dashboard-icons" style="font-size: 20px;"></i>
-      </div>
-      <a href="plugins/raintank-worldping-app/page/endpoint-config" class="kentik-dashboard-blurb">Add your first
-        endpoint.</a> <i class="tooltip-subtle grafana-tip tag-tip fa fa-question-circle ng-scope" bs-tooltip="'An endpoint is any domain, IP address</br>or URL you would like to monitor.'"></i>
-    </div>
-    <div ng-if="ctrl.endpointStatus !== 'noEndpoints'">
-        <i class="icon-gf icon-gf-check icon-gf-check kentik-icon-success"></i> Endpoint Detected.
-    </div>
-  </div>
-  -->
   <div class="kentik-dash-flex-item">
     <span class="kentik-dashboard-blurb">Complete:</span>
     <div class="kentik-CTA-item">

--- a/src/styles/pages/config.scss
+++ b/src/styles/pages/config.scss
@@ -27,9 +27,16 @@
   margin-right: $spacer;
 }
 
-.kentik-icon-success {
-  color: $online;
+.kentik-api-status-icon {
   font-size: 24px;
   text-decoration: none;
   vertical-align: sub;
+
+  &.success {
+    color: $online;
+  }
+
+  &.warning {
+    color: yellow;
+  }
 }


### PR DESCRIPTION
Fixes #31 

This PR makes it able to use the plugin for non-Admin Kentik users. 

> Note: non-Admin Kentik users have some limitations: they can't use Custom Dimensions in the dashboard filters. They'll see a warning about it on the plugin config save

## Before
![image](https://user-images.githubusercontent.com/1989898/94002815-15797780-fda3-11ea-8178-2ac7de4847d0.png)

## After
![image](https://user-images.githubusercontent.com/1989898/94003543-08a95380-fda4-11ea-8972-8e8f5679dd7c.png)

## Problem
The plugin is using a few Admin-level endpoints: `GET /users` (to check if it works) and `GET /customdimensions` which can't be used by non-Admin users

## Changes
- try to use `GET /devices` endpoint if `GET /users` fails with 403 error (that's how we check if user has Admin rights)
- display warning if user is not an Admin
- do not display alerts when dashboard get 403 errors on getting Custom Dimensions 