### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2020-09-25
+
+### Fixed
+
+- 403 error when using non-admin Kentik user [#31](https://github.com/kentik/kentik-grafana-app/issues/31)
+
 ## [1.4.0] - 2019-12-26
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Grafana docs about plugin installation: https://grafana.com/docs/plugins/install
 
 #### Install plugin
 ```bash
-grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.0/kentik-app-1.4.0.zip" plugins install kentik-app
+grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.zip" plugins install kentik-app
 sudo systemctl restart grafana-server
 ```
 
 #### Update plugin
 
 ```bash
-grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.0/kentik-app-1.4.0.zip" plugins update kentik-app
+grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.zip" plugins update kentik-app
 sudo systemctl restart grafana-server
 ```
 
@@ -63,7 +63,7 @@ sudo systemctl restart grafana-server
 
 - Download kentik-app
 ```bash
-wget https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.0/kentik-app-1.4.0.tar.gz
+wget https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.tar.gz
 ```
 
 - Remove old kentik-app (if it exists)
@@ -73,7 +73,7 @@ rm -rf kentik-app
 
 - Unpack downloaded files
 ```bash
-tar -zxvf kentik-app-1.4.0.tar.gz
+tar -zxvf kentik-app-1.4.1.tar.gz
 ```
 
 - Restart Grafana
@@ -90,7 +90,7 @@ You can install Kentik App to Grafana in Docker passing it as the environment va
 ```bash
 docker run \
   -p 3000:3000 \
-  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.0/kentik-app-1.4.0.zip;kentik-grafana-app" \
+  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.zip;kentik-grafana-app" \
   grafana/grafana
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kentik-app",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "",
   "scripts": {
     "build": "webpack --config build/webpack.prod.conf.js",


### PR DESCRIPTION
Changes:
- add changelog for 1.4.1 version
- package.json: bump version to 1.4.1
- change the plugin version in installation manual: 1.4.0 -> 1.4.1