### PR TITLE
Bump version to 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2021-05-21
+
+### Fixed
+
+- Filter field "inet_dst_addr" does not support the operator "=" error [#36](https://github.com/kentik/kentik-grafana-app/pull/36)
+
+### Changed
+- Remove old unsupported filters
+
 ## [1.4.1] - 2020-09-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ Grafana docs about plugin installation: https://grafana.com/docs/plugins/install
 
 #### Install plugin
 ```bash
-grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.zip" plugins install kentik-app
+grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.zip" plugins install kentik-app
 sudo systemctl restart grafana-server
 ```
 
 #### Update plugin
 
 ```bash
-grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.zip" plugins update kentik-app
+grafana-cli --pluginUrl "https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.zip" plugins update kentik-app
 sudo systemctl restart grafana-server
 ```
 
@@ -63,7 +63,7 @@ sudo systemctl restart grafana-server
 
 - Download kentik-app
 ```bash
-wget https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.tar.gz
+wget https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.tar.gz
 ```
 
 - Remove old kentik-app (if it exists)
@@ -73,7 +73,7 @@ rm -rf kentik-app
 
 - Unpack downloaded files
 ```bash
-tar -zxvf kentik-app-1.4.1.tar.gz
+tar -zxvf kentik-app-1.4.2.tar.gz
 ```
 
 - Restart Grafana
@@ -90,7 +90,7 @@ You can install Kentik App to Grafana in Docker passing it as the environment va
 ```bash
 docker run \
   -p 3000:3000 \
-  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.1/kentik-app-1.4.1.zip;kentik-grafana-app" \
+  -e "GF_INSTALL_PLUGINS=https://github.com/kentik/kentik-grafana-app/releases/download/v1.4.2/kentik-app-1.4.2.zip;kentik-grafana-app" \
   grafana/grafana
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kentik-app",
   "private": true,
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "",
   "scripts": {
     "build": "webpack --config build/webpack.prod.conf.js",


### PR DESCRIPTION
Changes:
- add changelog for 1.4.2 version
- package.json: bump version to 1.4.2
- change the plugin version in installation manual: 1.4.1 -> 1.4.2