### PR TITLE
Add dockerfile and build docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM node:12
+RUN apt-get update && \
+    apt-get install -y python vim less make zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+GRAFANA_API_KEY?=
+SIGN_ARGS?=
+VERSION?=dev
+
+all: build
+
+build: check-env
+	@docker build -t kentik-grafana-plugin:dev .
+	@docker run -ti --rm -e GRAFANA_API_KEY="$(GRAFANA_API_KEY)" -e VERSION="$(VERSION)" -e SIGN_ARGS="$(SIGN_ARGS)" -v $(shell pwd):/app -w /app kentik-grafana-plugin:dev make plugin
+
+plugin: check-env
+	@npm install
+	@yarn build
+	@npx @grafana/toolkit plugin:sign $(SIGN_ARGS)
+	@rm -rf kentik-connect-app
+	@mv dist kentik-connect-app
+	@zip -r kentik-connect-app-$(VERSION).zip kentik-connect-app
+	@rm -rf kentik-connect-app
+
+check-env:
+ifndef GRAFANA_API_KEY
+	$(error GRAFANA_API_KEY is undefined)
+endif
+
+.PHONY: check-env build plugin

--- a/README.md
+++ b/README.md
@@ -92,5 +92,34 @@ docker run \
   grafana/grafana
 ```
 
+## Build
+To produce a build of the plugin you will need [Docker](https://www.docker.com/products/docker-desktop). If you want to build locally without
+Docker then you can reference the `Dockerfile` for the required dependencies.
+
+To create a local package, use `make`:
+
+**Note:** you will need to have a Grafana API Key in order to create a build as the package is signed.
+
+```
+make GRAFANA_API_KEY=$GRAFANA_API_KEY
+```
+
+If the builds succeeds, it will produce an archive named `kentik-connect-app-dev.zip`.
+
+To specify a version, use the `VERSION` environment variable:
+
+```
+make GRAFANA_API_KEY=$GRAFANA_API_KEY VERSION=1.5.0
+```
+
+This will produce an archive named `kentik-connect-app-1.5.0.zip`.
+
+To add extra signing arguments use the `SIGN_ARGS` environment variable. For example, to specify a private archive
+for use on the `https://grafana-test.kentiklabs.com` domain:
+
+```
+make GRAFANA_API_KEY=$GRAFANA_API_KEY SIGN_ARGS="--rootUrls https://grafana-test.kentiklabs.com"
+```
+
 #### Useful links
 - Grafana docs about Docker installation: https://docs.grafana.org/installation/docker/#installing-plugins-from-other-sources

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "kentik-grafana-app",
-  "private": true,
+  "private": false,
   "version": "1.5.0",
-  "description": "",
+  "description": "Kentik Connect for Grafana allows you to quickly and easily enhance your visibility into your network traffic.",
   "scripts": {
     "build": "webpack --config build/webpack.prod.conf.js",
     "dev": "webpack --config build/webpack.dev.conf.js",


### PR DESCRIPTION
This adds a `Dockerfile` and build instructions to produce a Grafana plugin archive.