### PR TITLE
Fix "No root app page component found" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.7.1] - 2023-11-02
+
+#### Fixed
+
+- "No root app page component found" error [#82](https://github.com/kentik/kentik-grafana-app/pull/82)
+
 ## [1.7.0] - 2023-06-27
 
 **Please note, the release contains breaking changes.**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kentik-connect-app",
   "private": false,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Kentik Connect for Grafana allows you to quickly and easily enhance your visibility into your network traffic.",
   "scripts": {
     "build": "grafana-toolkit plugin:build",

--- a/src/components/DescriptionPanel.tsx
+++ b/src/components/DescriptionPanel.tsx
@@ -1,8 +1,8 @@
 import { KentikAPI } from '../datasource/kentik_api';
 
-import { getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv, locationService } from '@grafana/runtime';
 import { PanelProps, GrafanaTheme2 } from '@grafana/data';
-import { HorizontalGroup, VerticalGroup, useStyles2 } from '@grafana/ui';
+import { Button, useStyles2 } from '@grafana/ui';
 import React, { FC, useEffect, useState } from 'react';
 
 import { css } from '@emotion/css';
@@ -31,28 +31,20 @@ export const DescriptionPanel: FC<Props> = () => {
     });
   }
 
+  const handleTopTalkersClick = () => {
+    locationService.push('/d/NS58GIo71/kentik-top-talkers');
+  };
+
   return (
-    <div>
+    <div className={styles.container}>
       <img className={styles.image} src="public/plugins/kentik-connect-app/img/kentik_logo.png" />
-      <p>
+      <p className={styles.descriptionText}>
         Kentik Connect Pro for Grafana allows you to quickly and easily add network activity visibility metrics to your
         Grafana dashboard. By leveraging the power of Kentik’s monitoring SaaS, you can enjoy rich, actionable insights
         into consumers of network bandwidth and anomalies that can affect application or service performance.
       </p>
       <div className={styles.actionsContainer}>
-        <VerticalGroup>
-          <div>Complete:</div>
-          <HorizontalGroup>
-            <i className={styles.successIcon + ' icon-gf icon-gf-check'}></i>
-            <span className={styles.successLine}>Install Kentik Connect for Grafana.</span>
-          </HorizontalGroup>
-          {state.devices.length > 0 && (
-            <HorizontalGroup>
-              <i className={styles.successIcon + ' icon-gf icon-gf-check'}></i>
-              <span className={styles.successLine}>Add your first device.</span>
-            </HorizontalGroup>
-          )}
-        </VerticalGroup>
+        <Button variant={'primary'} fill={'text'} onClick={handleTopTalkersClick}>Kentik Top Talkers</Button>
       </div>
     </div>
   );
@@ -66,6 +58,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     width: 150px;
     margin-bottom: 10px;
   `,
+  container: css`
+    padding: 16px;
+  `,
   actionsContainer: css`
     margin-left: 16px;
   `,
@@ -78,5 +73,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   `,
   successLine: css`
     text-decoration: line-through;
+  `,
+  descriptionText: css`
+    max-width: 600px;
   `,
 });

--- a/src/components/DescriptionPanel.tsx
+++ b/src/components/DescriptionPanel.tsx
@@ -44,7 +44,9 @@ export const DescriptionPanel: FC<Props> = () => {
         into consumers of network bandwidth and anomalies that can affect application or service performance.
       </p>
       <div className={styles.actionsContainer}>
-        <Button variant={'primary'} fill={'text'} onClick={handleTopTalkersClick}>Kentik Top Talkers</Button>
+        <Button variant={'primary'} fill={'text'} onClick={handleTopTalkersClick}>
+          Kentik Top Talkers
+        </Button>
       </div>
     </div>
   );

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { DescriptionPanel } from 'components/DescriptionPanel';
 import { AppConfig } from './components/AppConfig';
 
 import './styles/dark.scss';
@@ -11,9 +12,12 @@ loadPluginCss({
   light: 'plugins/kentik-connect-app/styles/light.css',
 });
 
-export const plugin = new AppPlugin<{}>().addConfigPage({
-  title: 'Configuration',
-  icon: 'cog',
-  body: AppConfig,
-  id: 'configuration',
-});
+export const plugin = new AppPlugin<{}>()
+  // @ts-ignore
+  .setRootPage(DescriptionPanel)
+  .addConfigPage({
+    title: 'Configuration',
+    icon: 'cog',
+    body: AppConfig,
+    id: 'configuration',
+  });


### PR DESCRIPTION
## Changes:
- Description Panel: remove crossed out items, display link to Kentik Top Talkers instead  
- use Description Panel as the root page
- bump version to 1.7.1

## Before

![image](https://github.com/kentik/kentik-grafana-app/assets/1989898/3dd279e8-ffa7-40c3-9ec5-1b5026d14467)

## After 

![image](https://github.com/kentik/kentik-grafana-app/assets/1989898/1612672a-84e8-42ad-baac-fd5976979e57)