### PR TITLE
fix: resolve Grafana plugin submission validator errors

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -1,7 +1,7 @@
 services:
   grafana:
     user: root
-    container_name: 'kentik-datasource'
+    container_name: 'kentik-connect-datasource'
 
     build:
       context: .
@@ -13,13 +13,13 @@ services:
     ports:
       - 3000:3000/tcp
     volumes:
-      - ../dist:/var/lib/grafana/plugins/kentik-datasource
+      - ../dist:/var/lib/grafana/plugins/kentik-connect-datasource
       - ../provisioning:/etc/grafana/provisioning
-      - ..:/root/kentik-datasource
+      - ..:/root/kentik-connect-datasource
 
     environment:
       NODE_ENV: production
-      GF_LOG_FILTERS: plugin.kentik-datasource:debug
+      GF_LOG_FILTERS: plugin.kentik-connect-datasource:debug
       GF_LOG_LEVEL: debug
       GF_DATAPROXY_LOGGING: 1
-      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: kentik-datasource
+      GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: kentik-connect-datasource

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,32 +36,76 @@ jobs:
 
       - name: Package plugin
         run: |
-          mkdir -p /tmp/pkg/kentik-datasource
-          cp -r dist/* /tmp/pkg/kentik-datasource/
+          mkdir -p /tmp/pkg/kentik-connect-datasource
+          cp -r dist/* /tmp/pkg/kentik-connect-datasource/
           cd /tmp/pkg
-          zip -qr ${{ github.workspace }}/kentik-datasource.zip kentik-datasource
+          zip -qr ${{ github.workspace }}/kentik-connect-datasource.zip kentik-connect-datasource
 
       - name: Check zip structure
         run: |
           # Fail if dashboards are nested under a double dashboards/ path
-          if unzip -l ${{ github.workspace }}/kentik-datasource.zip | grep -q 'dashboards/dashboards/'; then
+          if unzip -l ${{ github.workspace }}/kentik-connect-datasource.zip | grep -q 'dashboards/dashboards/'; then
             echo "ERROR: zip contains dashboards/dashboards/ — duplicate copy detected"
-            unzip -l ${{ github.workspace }}/kentik-datasource.zip | grep dashboard
+            unzip -l ${{ github.workspace }}/kentik-connect-datasource.zip | grep dashboard
             exit 1
           fi
           # Confirm dashboards are present at the expected path
-          if ! unzip -l ${{ github.workspace }}/kentik-datasource.zip | grep -q 'kentik-datasource/dashboards/'; then
-            echo "ERROR: zip is missing kentik-datasource/dashboards/"
+          if ! unzip -l ${{ github.workspace }}/kentik-connect-datasource.zip | grep -q 'kentik-connect-datasource/dashboards/'; then
+            echo "ERROR: zip is missing kentik-connect-datasource/dashboards/"
             exit 1
           fi
           echo "Zip structure OK"
-          unzip -l ${{ github.workspace }}/kentik-datasource.zip | grep dashboard
+          unzip -l ${{ github.workspace }}/kentik-connect-datasource.zip | grep dashboard
+
+      - name: Upload plugin zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-zip
+          path: kentik-connect-datasource.zip
+          retention-days: 1
+
+      - name: Check for console logging in source
+        run: |
+          if grep -rn "console\.\(log\|warn\|error\|debug\|info\)" src/ --include="*.ts" --include="*.tsx" --exclude-dir="tests"; then
+            echo "ERROR: console logging detected — remove before submitting to Grafana"
+            exit 1
+          fi
+          echo "No console logging found"
+
+      - name: Check for @ts-ignore in source
+        run: |
+          if grep -rn "@ts-ignore\|@ts-expect-error" src/ --include="*.ts" --include="*.tsx" --exclude-dir="tests"; then
+            echo "ERROR: @ts-ignore/@ts-expect-error detected — fix TypeScript errors properly"
+            exit 1
+          fi
+          echo "No @ts-ignore found"
+
+      - name: Check for deprecated gf-form CSS classes
+        run: |
+          if grep -rn "gf-form" src/ --include="*.ts" --include="*.tsx" --include="*.css" --include="*.scss"; then
+            echo "ERROR: deprecated gf-form CSS class detected — use @grafana/ui components"
+            exit 1
+          fi
+          echo "No deprecated CSS classes found"
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout source (no dependencies installed)
+        uses: actions/checkout@v5
+
+      - name: Download plugin zip
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-zip
+          path: ${{ github.workspace }}
 
       - name: Validate plugin
         run: |
           npx -y @grafana/plugin-validator@latest \
             -sourceCodeUri file://${{ github.workspace }} \
-            ${{ github.workspace }}/kentik-datasource.zip
+            ${{ github.workspace }}/kentik-connect-datasource.zip
 
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*' # Run workflow on version tags, e.g. v2.0.0
 
 env:
-  PLUGIN_ID: kentik-datasource
+  PLUGIN_ID: kentik-connect-datasource
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ All notable changes to this project will be documented in this file.
 
 **Breaking changes:**
 
-- Minimum Grafana version: 10.4.0
+- Minimum Grafana version: 11.6.0
+- Plugin type changed from `app` to `datasource`; plugin ID changed from `kentik-connect-app` to `kentik-connect-datasource` (required by Grafana's validator — datasource plugins must use the `-datasource` suffix). Both plugins can run side-by-side; existing `kentik-connect-app` v1.7.0 dashboards remain functional while you migrate at your own pace. See [v2.0.0 release notes](docs/v2.0.0-release.md) for migration steps.
 
 ## [1.7.0] - 2023-06-27
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Kentik for Grafana
 
+> **Upgrading from v1.7.0 (`kentik-connect-app`)?** v2.0.0 is published as a new plugin (`kentik-connect-datasource`) because Grafana requires datasource plugins to use the `-datasource` ID suffix, the two plugins can coexist on the same Grafana instance without conflict. Your existing v1.7.0 dashboards and configuration remain fully functional while you migrate at your own pace. See the [v2.0.0 release notes](docs/v2.0.0-release.md) for migration steps.
+
 The Kentik datasource plugin allows you to query the Kentik API and visualize network traffic data directly in Grafana. It leverages the **Kentik Network Observability Platform** to provide real-time, Internet-scale ingest and querying of network data including flow records (NetFlow, IPFIX, sFlow), BGP, GeoIP, and SNMP.
 
 The plugin provides instant access to the **Kentik Data Engine (KDE)**, enabling you to seamlessly integrate network activity metrics into your Grafana dashboards with improved performance and flexibility.

--- a/dashboards/kentik-home.json
+++ b/dashboards/kentik-home.json
@@ -20,7 +20,7 @@
       "id": 1,
       "options": {
         "mode": "markdown",
-        "content": "![Kentik](public/plugins/kentik-datasource/img/logo_large.png)\n\n# Kentik for Grafana\n\nKentik for Grafana allows you to quickly and easily add network activity visibility metrics to your Grafana dashboard.\n\nBy leveraging the power of Kentik's monitoring SaaS, you can enjoy rich, actionable insights into consumers of network bandwidth and anomalies that can affect application or service performance.\n\n**Getting Started:**\n1. ✅ Install Kentik for Grafana\n2. Configure your [Kentik datasource](/connections/datasources) with API credentials\n3. Explore the dashboards in the Kentik folder →"
+        "content": "![Kentik](public/plugins/kentik-connect-datasource/img/logo_large.png)\n\n# Kentik for Grafana\n\nKentik for Grafana allows you to quickly and easily add network activity visibility metrics to your Grafana dashboard.\n\nBy leveraging the power of Kentik's monitoring SaaS, you can enjoy rich, actionable insights into consumers of network bandwidth and anomalies that can affect application or service performance.\n\n**Getting Started:**\n1. ✅ Install Kentik for Grafana\n2. Configure your [Kentik datasource](/connections/datasources) with API credentials\n3. Explore the dashboards in the Kentik folder →"
       },
       "fieldConfig": {
         "defaults": {},

--- a/dashboards/kentik-osi-health.json
+++ b/dashboards/kentik-osi-health.json
@@ -30,7 +30,7 @@
         "y": 0
       },
       "id": 100,
-      "title": "🔌 Physical: Interface & Device Health",
+      "title": "\ud83d\udd0c Physical: Interface & Device Health",
       "type": "row"
     },
     {
@@ -45,8 +45,8 @@
       },
       "id": 1,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -66,8 +66,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -111,8 +111,8 @@
       },
       "id": 2,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -132,8 +132,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -177,8 +177,8 @@
       },
       "id": 1002,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -192,13 +192,13 @@
           ],
           "hostnameLookup": "enabled",
           "prefix": "Memory",
-          "aliasBy": "{{i_device_id}} — Memory",
+          "aliasBy": "{{i_device_id}} \u2014 Memory",
           "topx": "10",
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -238,8 +238,8 @@
       },
       "id": 1001,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -253,13 +253,13 @@
           ],
           "hostnameLookup": "enabled",
           "prefix": "CPU",
-          "aliasBy": "{{i_device_id}} — CPU %",
+          "aliasBy": "{{i_device_id}} \u2014 CPU %",
           "topx": "10",
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -296,12 +296,12 @@
         "y": 17
       },
       "id": 101,
-      "title": "🔗 Data Link: VLANs & MAC Addresses",
+      "title": "\ud83d\udd17 Data Link: VLANs & MAC Addresses",
       "type": "row"
     },
     {
       "title": "Traffic by Source VLAN",
-      "description": "VLAN distribution — identify VLAN congestion or misconfiguration",
+      "description": "VLAN distribution \u2014 identify VLAN congestion or misconfiguration",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -311,8 +311,8 @@
       },
       "id": 3,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -331,8 +331,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -366,7 +366,7 @@
     },
     {
       "title": "Traffic by Source MAC Address",
-      "description": "MAC address distribution — identify top L2 endpoints",
+      "description": "MAC address distribution \u2014 identify top L2 endpoints",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -376,8 +376,8 @@
       },
       "id": 4,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -396,8 +396,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -438,7 +438,7 @@
         "y": 26
       },
       "id": 102,
-      "title": "🌐 Network: IP, BGP & Geography",
+      "title": "\ud83c\udf10 Network: IP, BGP & Geography",
       "type": "row"
     },
     {
@@ -453,8 +453,8 @@
       },
       "id": 5,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -473,8 +473,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -518,8 +518,8 @@
       },
       "id": 6,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -538,8 +538,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -573,7 +573,7 @@
     },
     {
       "title": "Traffic by Source AS Number",
-      "description": "BGP origin AS — which networks are sending you traffic",
+      "description": "BGP origin AS \u2014 which networks are sending you traffic",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -583,8 +583,8 @@
       },
       "id": 7,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -603,8 +603,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -648,8 +648,8 @@
       },
       "id": 8,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -668,8 +668,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -711,8 +711,8 @@
       },
       "id": 9,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -731,8 +731,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -771,7 +771,7 @@
         "y": 45
       },
       "id": 103,
-      "title": "🚢 Transport: Protocols & Ports",
+      "title": "\ud83d\udea2 Transport: Protocols & Ports",
       "type": "row"
     },
     {
@@ -786,8 +786,8 @@
       },
       "id": 10,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -806,8 +806,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -851,8 +851,8 @@
       },
       "id": 11,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -871,8 +871,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -916,8 +916,8 @@
       },
       "id": 12,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -936,8 +936,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -971,7 +971,7 @@
     },
     {
       "title": "Packets/s by Protocol",
-      "description": "Packet rate per transport protocol — useful for detecting small-packet floods",
+      "description": "Packet rate per transport protocol \u2014 useful for detecting small-packet floods",
       "type": "timeseries",
       "gridPos": {
         "h": 8,
@@ -981,8 +981,8 @@
       },
       "id": 13,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -1001,8 +1001,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -1043,12 +1043,12 @@
         "y": 62
       },
       "id": 104,
-      "title": "📡 Endpoints & Connection Patterns",
+      "title": "\ud83d\udce1 Endpoints & Connection Patterns",
       "type": "row",
       "panels": [
         {
           "title": "Flows/s by Source IP (Connection Density)",
-          "description": "Flow rate as a proxy for session/connection density — spikes may indicate scanning or DDoS",
+          "description": "Flow rate as a proxy for session/connection density \u2014 spikes may indicate scanning or DDoS",
           "type": "timeseries",
           "gridPos": {
             "h": 8,
@@ -1058,8 +1058,8 @@
           },
           "id": 14,
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           },
           "targets": [
             {
@@ -1078,8 +1078,8 @@
               "customFilters": [],
               "conjunctionOperator": "AND",
               "datasource": {
-                "type": "kentik-datasource",
-                "uid": "kentik-datasource-dev"
+                "type": "kentik-connect-datasource",
+                "uid": "kentik"
               }
             }
           ],
@@ -1110,7 +1110,7 @@
         },
         {
           "title": "Unique Source IPs",
-          "description": "Cardinality of unique source endpoints — sudden changes indicate new traffic patterns",
+          "description": "Cardinality of unique source endpoints \u2014 sudden changes indicate new traffic patterns",
           "type": "timeseries",
           "gridPos": {
             "h": 8,
@@ -1120,8 +1120,8 @@
           },
           "id": 15,
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           },
           "targets": [
             {
@@ -1135,13 +1135,13 @@
               ],
               "hostnameLookup": "disabled",
               "prefix": "Uniq Src",
-              "aliasBy": "{{InterfaceID_src}} — $col",
+              "aliasBy": "{{InterfaceID_src}} \u2014 $col",
               "topx": "10",
               "customFilters": [],
               "conjunctionOperator": "AND",
               "datasource": {
-                "type": "kentik-datasource",
-                "uid": "kentik-datasource-dev"
+                "type": "kentik-connect-datasource",
+                "uid": "kentik"
               }
             }
           ],
@@ -1181,7 +1181,7 @@
         "y": 63
       },
       "id": 105,
-      "title": "🌍 Application Services",
+      "title": "\ud83c\udf0d Application Services",
       "type": "row",
       "panels": [
         {
@@ -1196,8 +1196,8 @@
           },
           "id": 16,
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           },
           "targets": [
             {
@@ -1216,8 +1216,8 @@
               "customFilters": [],
               "conjunctionOperator": "AND",
               "datasource": {
-                "type": "kentik-datasource",
-                "uid": "kentik-datasource-dev"
+                "type": "kentik-connect-datasource",
+                "uid": "kentik"
               }
             }
           ],
@@ -1251,7 +1251,7 @@
         },
         {
           "title": "Traffic by IP Protocol + Port",
-          "description": "Combined protocol and port view — TCP:443 vs UDP:53 vs TCP:22 etc.",
+          "description": "Combined protocol and port view \u2014 TCP:443 vs UDP:53 vs TCP:22 etc.",
           "type": "timeseries",
           "gridPos": {
             "h": 8,
@@ -1261,8 +1261,8 @@
           },
           "id": 17,
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           },
           "targets": [
             {
@@ -1282,8 +1282,8 @@
               "customFilters": [],
               "conjunctionOperator": "AND",
               "datasource": {
-                "type": "kentik-datasource",
-                "uid": "kentik-datasource-dev"
+                "type": "kentik-connect-datasource",
+                "uid": "kentik"
               }
             }
           ],
@@ -1313,7 +1313,7 @@
           "links": []
         },
         {
-          "title": "Full Network Overview — All Dimensions Table",
+          "title": "Full Network Overview \u2014 All Dimensions Table",
           "description": "Sortable table view across key dimensions with Max, 95th Percentile, and Average",
           "type": "table",
           "gridPos": {
@@ -1324,8 +1324,8 @@
           },
           "id": 18,
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           },
           "targets": [
             {
@@ -1339,13 +1339,13 @@
               ],
               "hostnameLookup": "enabled",
               "prefix": "",
-              "aliasBy": "{{InterfaceID_src}} — $col",
+              "aliasBy": "{{InterfaceID_src}} \u2014 $col",
               "topx": "25",
               "customFilters": [],
               "conjunctionOperator": "AND",
               "datasource": {
-                "type": "kentik-datasource",
-                "uid": "kentik-datasource-dev"
+                "type": "kentik-connect-datasource",
+                "uid": "kentik"
               }
             }
           ],

--- a/dashboards/kentik-site-overview.json
+++ b/dashboards/kentik-site-overview.json
@@ -23,7 +23,7 @@
   "panels": [
     {
       "title": "Protocol Traffic Density (Heatmap)",
-      "description": "Heatmap showing traffic volume distribution across protocols over time — bright cells indicate burst activity",
+      "description": "Heatmap showing traffic volume distribution across protocols over time \u2014 bright cells indicate burst activity",
       "type": "heatmap",
       "gridPos": {
         "h": 9,
@@ -33,8 +33,8 @@
       },
       "id": 1,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -53,8 +53,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -90,7 +90,7 @@
     },
     {
       "title": "Device Flow Activity (Status History)",
-      "description": "Status history showing per-device flow rates over time — red indicates low/no flows (possible collection outage), green indicates healthy activity",
+      "description": "Status history showing per-device flow rates over time \u2014 red indicates low/no flows (possible collection outage), green indicates healthy activity",
       "type": "status-history",
       "gridPos": {
         "h": 8,
@@ -100,8 +100,8 @@
       },
       "id": 2,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -120,8 +120,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],
@@ -143,9 +143,18 @@
           "thresholds": {
             "mode": "absolute",
             "steps": [
-              { "color": "red", "value": null },
-              { "color": "orange", "value": 10 },
-              { "color": "green", "value": 100 }
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 10
+              },
+              {
+                "color": "green",
+                "value": 100
+              }
             ]
           },
           "custom": {
@@ -159,7 +168,7 @@
     },
     {
       "title": "Site Traffic Overview (Bar Chart)",
-      "description": "Traffic volume by site — quickly identify which sites are driving the most bandwidth",
+      "description": "Traffic volume by site \u2014 quickly identify which sites are driving the most bandwidth",
       "type": "barchart",
       "gridPos": {
         "h": 10,
@@ -169,8 +178,8 @@
       },
       "id": 3,
       "datasource": {
-        "type": "kentik-datasource",
-        "uid": "kentik-datasource-dev"
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
       "targets": [
         {
@@ -189,8 +198,8 @@
           "customFilters": [],
           "conjunctionOperator": "AND",
           "datasource": {
-            "type": "kentik-datasource",
-            "uid": "kentik-datasource-dev"
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
         }
       ],

--- a/dashboards/kentik-top-talkers.json
+++ b/dashboards/kentik-top-talkers.json
@@ -1,325 +1,353 @@
 {
-    "uid": "NS58GIo71",
-    "title": "Kentik Top Talkers",
-    "originalTitle": "Kentik Top Talkers",
-    "tags": ["kentik"],
-    "style": "dark",
-    "timezone": "",
-    "editable": true,
-    "hideControls": false,
-    "sharedCrosshair": false,
-    "panels": [
-      {
-        "datasource": {"type": "kentik-datasource"},
-        "id": 1,
-        "links": [],
-        "targets": [
-          {
-            "devices": "$devices",
-            "hostnameLookup": "$dns_lookup",
-            "dimension": "$dimension",
-            "mode": "graph",
-            "refId": "A",
-            "target": "",
-            "metric": "$metric",
-            "aliasBy": "",
-            "prefix": "",
-            "datasource": {"type": "kentik-datasource"}
-          }
-        ],
-        "title": "Kentik Network Flow Data",
-        "type": "timeseries",
-        "gridPos": {
-          "x": 0,
-          "y": 0,
-          "w": 24,
-          "h": 11
-        },
-        "options": {
-          "tooltip": {
-            "mode": "multi",
-            "sort": "none"
-          },
-          "legend": {
-            "showLegend": true,
-            "displayMode": "table",
-            "placement": "right",
-            "calcs": []
-          }
-        },
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "linear",
-              "barAlignment": 0,
-              "lineWidth": 2,
-              "fillOpacity": 10,
-              "gradientMode": "none",
-              "spanNulls": true,
-              "showPoints": "never",
-              "pointSize": 5,
-              "stacking": {
-                "mode": "normal",
-                "group": "A"
-              },
-              "axisPlacement": "auto",
-              "axisLabel": "",
-              "axisColorMode": "text",
-              "scaleDistribution": {
-                "type": "linear"
-              },
-              "axisCenteredZero": false,
-              "hideFrom": {
-                "tooltip": false,
-                "viz": false,
-                "legend": false
-              },
-              "thresholdsStyle": {
-                "mode": "off"
-              }
-            },
-            "color": {
-              "mode": "palette-classic"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "value": null,
-                  "color": "green"
-                },
-                {
-                  "value": 80,
-                  "color": "red"
-                }
-              ]
-            },
-            "unit": "bps"
-          },
-          "overrides": []
-        },
-        "pluginVersion": "10.1.0-118674pre",
-        "timeFrom": null,
-        "timeShift": null
+  "uid": "NS58GIo71",
+  "title": "Kentik Top Talkers",
+  "originalTitle": "Kentik Top Talkers",
+  "tags": [
+    "kentik"
+  ],
+  "style": "dark",
+  "timezone": "",
+  "editable": true,
+  "hideControls": false,
+  "sharedCrosshair": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
       },
-      {
-        "datasource": {"type": "kentik-datasource"},
-        "id": 2,
-        "links": [],
-        "targets": [
-          {
-            "devices": "$devices",
-            "hostnameLookup": "$dns_lookup",
-            "dimension": "$dimension",
-            "mode": "table",
-            "refId": "A",
-            "target": "",
-            "metric": "$metric",
-            "aliasBy": "",
-            "prefix": "",
-            "datasource": {"type": "kentik-datasource"}
+      "id": 1,
+      "links": [],
+      "targets": [
+        {
+          "devices": "$devices",
+          "hostnameLookup": "$dns_lookup",
+          "dimension": "$dimension",
+          "mode": "graph",
+          "refId": "A",
+          "target": "",
+          "metric": "$metric",
+          "aliasBy": "",
+          "prefix": "",
+          "datasource": {
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
           }
-        ],
-        "type": "table",
-        "gridPos": {
-          "x": 0,
-          "y": 11,
-          "w": 24,
-          "h": 9
-        },
-        "fieldConfig": {
-          "defaults": {
-            "custom": {
-              "align": "auto",
-              "cellOptions": {
-                "type": "auto"
-              },
-              "inspect": false
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "value": null,
-                  "color": "green"
-                },
-                {
-                  "value": 80,
-                  "color": "red"
-                }
-              ]
-            },
-            "color": {
-              "mode": "thresholds"
-            }
-          },
-          "overrides": [
-            {
-              "matcher": {
-                "id": "byRegexp",
-                "options": "/^(Max|95th|p95th|Avg|Average)/"
-              },
-              "properties": [
-                {
-                  "id": "unit",
-                  "value": "short"
-                },
-                {
-                  "id": "decimals",
-                  "value": 2
-                },
-                {
-                  "id": "custom.align",
-                  "value": null
-                }
-              ]
-            }
-          ]
-        },
-        "options": {
-          "showHeader": true,
-          "cellHeight": "sm",
-          "footer": {
-            "show": false,
-            "reducer": [
-              "sum"
-            ],
-            "countRows": false,
-            "fields": ""
-          }
-        },
-        "transformations": [
-          {
-            "id": "merge",
-            "options": {
-              "reducers": []
-            }
-          }
-        ],
-        "pluginVersion": "10.1.0-118674pre"
-      }
-    ],
-    "time": {
-      "from": "now-30m",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
+        }
       ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
-    },
-    "templating": {
-      "list": [
-        {
-          "allValue": null,
-          "current": {
-            "tags": [],
-            "text": "disabled",
-            "value": "disabled"
-          },
-          "hide": 0,
-          "includeAll": false,
-          "label": "DNS Lookup",
-          "multi": false,
-          "name": "dns_lookup",
-          "options": [
-            {
-              "selected": false,
-              "text": "enabled",
-              "value": "enabled"
-            },
-            {
-              "selected": true,
-              "text": "disabled",
-              "value": "disabled"
-            }
-          ],
-          "query": "enabled,disabled",
-          "skipUrlSync": false,
-          "type": "custom"
+      "title": "Kentik Network Flow Data",
+      "type": "timeseries",
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 24,
+        "h": 11
+      },
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
         },
-        {
-          "current": {
-            "tags": [],
-            "text": "All",
-            "value": [
-              "$__all"
+        "legend": {
+          "showLegend": true,
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "barAlignment": 0,
+            "lineWidth": 2,
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "spanNulls": true,
+            "showPoints": "never",
+            "pointSize": 5,
+            "stacking": {
+              "mode": "normal",
+              "group": "A"
+            },
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "axisCenteredZero": false,
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 80,
+                "color": "red"
+              }
             ]
           },
-          "datasource": {"type": "kentik-datasource"},
-          "hide": 0,
-          "includeAll": true,
-          "label": "Devices",
-          "multi": true,
-          "name": "devices",
-          "options": [],
-          "query": "devices()",
-          "refresh": 1,
-          "type": "query"
+          "unit": "bps"
         },
+        "overrides": []
+      },
+      "pluginVersion": "10.1.0-118674pre",
+      "timeFrom": null,
+      "timeShift": null
+    },
+    {
+      "datasource": {
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
+      },
+      "id": 2,
+      "links": [],
+      "targets": [
         {
-          "current": {"value": "InterfaceID_src", "text": "Source Interface"},
-          "datasource": {"type": "kentik-datasource"},
-          "hide": 0,
-          "includeAll": false,
-          "label": "Group By",
-          "multi": false,
-          "name": "dimension",
-          "options": [],
-          "query": "dimensions()",
-          "refresh": 1,
-          "type": "query"
-        },
-        {
-          "current": {},
-          "datasource": {"type": "kentik-datasource"},
-          "hide": 0,
-          "includeAll": false,
-          "label": "Metric",
-          "multi": false,
-          "name": "metric",
-          "options": [],
-          "query": "metricsOptions()",
-          "refresh": 1,
-          "regex": "",
-          "type": "query"
-        },
-        {
-  
-          "datasource": {"type": "kentik-datasource"},
-          "filters": [],
-          "hide": 0,
-          "label": "",
-          "name": "Filters",
-          "type": "adhoc"
+          "devices": "$devices",
+          "hostnameLookup": "$dns_lookup",
+          "dimension": "$dimension",
+          "mode": "table",
+          "refId": "A",
+          "target": "",
+          "metric": "$metric",
+          "aliasBy": "",
+          "prefix": "",
+          "datasource": {
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
+          }
         }
-      ]
-    },
-    "annotations": {
-      "list": []
-    },
-    "refresh": false,
-    "schemaVersion": 12,
-    "revision": 4,
-    "links": []
-  }
+      ],
+      "type": "table",
+      "gridPos": {
+        "x": 0,
+        "y": 11,
+        "w": 24,
+        "h": 9
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "value": null,
+                "color": "green"
+              },
+              {
+                "value": 80,
+                "color": "red"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/^(Max|95th|p95th|Avg|Average)/"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              },
+              {
+                "id": "custom.align",
+                "value": null
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {
+            "reducers": []
+          }
+        }
+      ],
+      "pluginVersion": "10.1.0-118674pre"
+    }
+  ],
+  "time": {
+    "from": "now-30m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "tags": [],
+          "text": "disabled",
+          "value": "disabled"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "DNS Lookup",
+        "multi": false,
+        "name": "dns_lookup",
+        "options": [
+          {
+            "selected": false,
+            "text": "enabled",
+            "value": "enabled"
+          },
+          {
+            "selected": true,
+            "text": "disabled",
+            "value": "disabled"
+          }
+        ],
+        "query": "enabled,disabled",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "tags": [],
+          "text": "All",
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": {
+          "type": "kentik-connect-datasource",
+          "uid": "kentik"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Devices",
+        "multi": true,
+        "name": "devices",
+        "options": [],
+        "query": "devices()",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "value": "InterfaceID_src",
+          "text": "Source Interface"
+        },
+        "datasource": {
+          "type": "kentik-connect-datasource",
+          "uid": "kentik"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Group By",
+        "multi": false,
+        "name": "dimension",
+        "options": [],
+        "query": "dimensions()",
+        "refresh": 1,
+        "type": "query"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "kentik-connect-datasource",
+          "uid": "kentik"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Metric",
+        "multi": false,
+        "name": "metric",
+        "options": [],
+        "query": "metricsOptions()",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "kentik-connect-datasource",
+          "uid": "kentik"
+        },
+        "filters": [],
+        "hide": 0,
+        "label": "",
+        "name": "Filters",
+        "type": "adhoc"
+      }
+    ]
+  },
+  "annotations": {
+    "list": []
+  },
+  "refresh": false,
+  "schemaVersion": 12,
+  "revision": 4,
+  "links": []
+}

--- a/docs/v2.0.0-release.md
+++ b/docs/v2.0.0-release.md
@@ -1,0 +1,475 @@
+# Kentik Grafana Plugin v2.0.0 — Release Documentation
+
+## Contents
+
+1. [What's New — Summary](#whats-new--summary)
+2. [Breaking Changes & Upgrade Notes](#breaking-changes--upgrade-notes)
+3. [Query Editor Field Reference](#query-editor-field-reference)
+4. [Alias By — Detailed Guide](#alias-by--detailed-guide)
+5. [New Dimensions in v2.0.0](#new-dimensions-in-v200)
+6. [Bundled Dashboards](#bundled-dashboards)
+7. [Field Team Notes](#field-team-notes)
+
+---
+
+## What's New — Summary
+
+v2.0.0 is a complete rebuild on the Grafana 12 SDK. It replaces the v1.7.0
+React migration with a modern, full-featured datasource plugin — adding portal
+deep-linking, a batch query scheduler, an expanded dimension library, a richer
+query editor, and four bundled dashboards.
+
+### Highlights
+
+| Feature | v1.7.0 | v2.0.0 |
+|---|---|---|
+| Grafana SDK | Grafana 8 | Grafana 12 |
+| Minimum Grafana version | 8.3 | 11.6 |
+| Plugin type | `app` | `datasource` |
+| Bundled dashboards | 1 | 4 |
+| Deep-link to Kentik portal | ✗ | ✅ |
+| Batch query scheduler | ✗ | ✅ |
+| EU region support | ✗ | ✅ |
+| Kubernetes dimensions | ✗ | ✅ |
+| OTT dimensions | ✗ | ✅ |
+| Kappa (process telemetry) dimensions | ✗ | ✅ |
+| Data mode (Graph / Table) | ✗ | ✅ |
+| Top-N control per panel | ✗ | ✅ |
+| Custom filter builder UI | ✗ | ✅ |
+| Alias By autocomplete | ✗ | ✅ |
+| CI/CD | CircleCI + Makefile | GitHub Actions |
+
+### Deep-link to Kentik Portal
+
+Every panel now includes a link icon that opens the Kentik portal scoped to the
+same query, time range, and filters currently visible in Grafana. The portal URL
+is automatically derived from the configured region — US, EU, and custom-hosted
+environments are all supported.
+
+### Batch Query Scheduler
+
+Multiple panels on the same dashboard execute as a single batched API request to
+Kentik's TopXData endpoint instead of N individual requests. Falls back to
+individual queries if the batch fails. On dashboards with many panels, load time
+typically improves 3–5x.
+
+### EU Region Support
+
+A new **Region** dropdown in the datasource configuration page supports:
+- **US** (default) — `api.kentik.com`
+- **EU** — `api.kentik.eu`
+- **Custom** — user-supplied API endpoint, with portal URL auto-derived
+
+---
+
+## Breaking Changes & Upgrade Notes
+
+### Minimum Grafana version: 11.6
+
+Customers on Grafana 11.x or earlier must upgrade Grafana before installing the
+v2.0.0 plugin. There is no workaround.
+
+### Plugin type changed
+
+v1.7.0 was an `app` plugin with ID `kentik-connect-datasource`.  
+v2.0.0 is a `datasource` plugin, also with ID `kentik-connect-datasource`.
+
+The plugin ID is **unchanged** — v2.0.0 is an in-place upgrade of the existing
+catalog entry. Existing dashboards referencing `kentik-connect-datasource` as their
+datasource type will continue to work without remapping.
+
+Existing credentials and configuration do **not** carry over — users will need
+to re-enter their Kentik email and API token in the updated datasource
+configuration page after upgrading.
+
+### Side-by-side installation
+
+Because both versions share the same plugin ID (`kentik-connect-datasource`), only one
+can be active at a time. Grafana will use whichever version is installed.
+
+---
+
+## Query Editor Field Reference
+
+### Data Mode
+
+Controls the output format of the panel.
+
+| Value | Behavior |
+|---|---|
+| **Graph** (default) | Time-series visualization. Each dimension combination is a separate series plotted over time. |
+| **Table** | Summary table. Returns the top-N results ranked by the selected metric with Max, 95th percentile, and Average columns. |
+
+---
+
+### Sites
+
+Filters data to one or more Kentik sites. Populated dynamically from your
+Kentik account.
+
+- Select **All Sites** to include traffic from all sites
+- Select one or more specific sites to narrow the query
+- Supports Grafana template variables (e.g. `$site`)
+
+**Required.** A query will not execute without a site selection.
+
+---
+
+### Devices
+
+Filters data to one or more devices within the selected sites. Populated
+dynamically based on the Sites selection.
+
+- Select **All Devices** to include all devices within the selected sites
+- Select specific devices to narrow further
+- Supports Grafana template variables (e.g. `$device`)
+
+---
+
+### Dimension
+
+The field(s) to group traffic by. Controls what each series or table row
+represents.
+
+- Up to **8 dimensions** can be selected per query
+- Dimensions are organized into categories (General, Network, DNS, BGP, GeoIP,
+  Cloud, Kubernetes, OTT, SNMP/ST, etc.)
+- Selecting multiple dimensions groups by the combination, similar to a SQL
+  `GROUP BY` with multiple columns
+- Supports Grafana template variables
+
+**Required.**
+
+---
+
+### Metric
+
+The value to measure and sort results by.
+
+Examples: `Bits/s`, `Packets/s`, `Unique Src IPs`, `Retransmits/s`
+
+- Only one metric can be selected per query
+- The metric determines what the Y-axis represents in Graph mode and the sort
+  order in Table mode
+- Supports Grafana template variables
+
+**Required.**
+
+---
+
+### Top N
+
+Controls how many results to return. Default: **8**.
+
+In Graph mode this is the number of series shown (e.g. top 8 source IPs).
+In Table mode this is the number of rows returned.
+
+Increase for wider panels or when you need more coverage. Higher values increase
+API response time.
+
+---
+
+### Hostname Lookup
+
+When enabled, Grafana will attempt to resolve IP addresses to hostnames in the
+series labels.
+
+| Value | Behavior |
+|---|---|
+| **Enabled** | IPs resolved to hostnames where available |
+| **Disabled** (default) | Raw IP addresses shown |
+
+---
+
+### Filters
+
+Custom filter expressions to narrow the query beyond site and device selection.
+Equivalent to WHERE clauses in SQL.
+
+Each filter row has:
+- **Key** — the dimension field to filter on (e.g. `src_geo_country`, `Proto`)
+- **Operator** — `=`, `!=`, `<`, `<=`, `>`, `>=`
+- **Value** — the value to match
+
+Multiple filters are combined using a **conjunction operator**:
+- **AND** (default) — all conditions must match
+- **OR** — any condition can match
+
+The conjunction operator applies globally to all filters in the query. It is
+displayed as a label between filter rows and can be toggled at the top of the
+filter section.
+
+**Example:** Show only TCP traffic from the United States:
+```
+src_geo_country = US
+AND
+Proto = TCP
+```
+
+---
+
+### Prefix
+
+A static string prepended to every series label. Can also contain `$tag_` and
+`{{}}` tokens (see Alias By below).
+
+**Example:** Setting Prefix to `prod` and Alias By to `$tag_src_as` produces
+labels like `prod 15169`.
+
+---
+
+### Alias By
+
+Controls the series label template. Supports token substitution from the series
+data. If left empty, series are labeled by their `key` value from Kentik
+(typically the dimension values joined by commas).
+
+See the [Alias By — Detailed Guide](#alias-by--detailed-guide) section below.
+
+---
+
+## Alias By — Detailed Guide
+
+### Overview
+
+The **Alias By** field lets you build human-readable series labels using values
+from the Kentik response. Two token syntaxes are supported, along with two
+built-in variables.
+
+Autocomplete is available — type `$tag_` or `{{` and a dropdown of available
+dimension fields appears.
+
+---
+
+### `$tag_<field>` — shorthand tag substitution
+
+Replaces the token with the value of `<field>` from the series data.
+
+**Restriction:** Field name must match `[a-zA-Z0-9_.]` — no spaces or hyphens.
+Use `{{...}}` for field names with spaces or hyphens.
+
+| Alias By | Example result |
+|---|---|
+| `$tag_src_as` | `15169` |
+| `$tag_dst_geo_country` | `United States` |
+| `$tag_Proto` | `TCP` |
+| `$tag_device` | `core-router-01` |
+| `$tag_src_geo_city` | `Seattle` |
+
+---
+
+### `{{field}}` — explicit tag substitution
+
+Same behavior as `$tag_` but delimited by double braces. Supports spaces and
+hyphens in field names, and is visually unambiguous in complex strings.
+
+| Alias By | Example result |
+|---|---|
+| `{{src_as}}` | `15169` |
+| `{{dst-geo-country}}` | `United States` |
+| `{{Source Port}}` | `443` |
+| `{{device}}` | `core-router-01` |
+
+---
+
+### `$col` — aggregate column label
+
+Replaced with the friendly label of the aggregate being charted (e.g.
+`Max bits/s`, `95th Percentile`).
+
+| Alias By | Example result |
+|---|---|
+| `$tag_src_as ($col)` | `15169 (Max bits/s)` |
+| `{{device}} — $col` | `core-router-01 — 95th Percentile` |
+
+---
+
+### `$metric_group` — metric group name
+
+Replaced with the metric group name. Useful when a panel queries across multiple
+metric types.
+
+| Alias By | Example result |
+|---|---|
+| `$metric_group: $tag_device` | `SNMP Device CPU (%): core-router-01` |
+
+---
+
+### Combining tokens
+
+Tokens can be freely mixed with static text.
+
+| Alias By | Prefix | Example result |
+|---|---|---|
+| `$tag_src_as — $tag_dst_as` | *(empty)* | `15169 — 16509` |
+| `$tag_src_geo_country ($col)` | `Inbound` | `Inbound United States (Max bits/s)` |
+| `{{device}} / {{interface}}` | *(empty)* | `core-router-01 / xe-0/0/1` |
+
+---
+
+### Grafana dashboard variables
+
+Grafana template variables (e.g. `$region`) can be embedded in Alias By. They
+resolve to the human-readable selected value before token substitution runs.
+Multi-value variables display as `All` rather than expanding to every value.
+
+| Alias By | Variable value | Example result |
+|---|---|---|
+| `$region: $tag_src_as` | `$region = us-east` | `us-east: 15169` |
+| `{{$device}} $tag_Proto` | `$device = router-01` | `router-01 TCP` |
+
+---
+
+### Fallback resolution order
+
+When a tag name doesn't exactly match a field in the series data, the plugin
+tries these steps in order:
+
+1. Exact property match on the series object
+2. Case-insensitive match
+3. Kentik field name variants: `i_<field>`, `<field>_name`, `i_<field>_name`
+4. SNMP/ST protocol keys: `ktappprotocol__...__<field>`
+5. Position in `series.key` by dimension index
+
+If no match is found, the token is left as-is (e.g. `$tag_missing` stays
+`$tag_missing` in the label).
+
+---
+
+## New Dimensions in v2.0.0
+
+The following dimension categories are new in v2.0.0.
+
+### Kubernetes
+
+Group traffic by Kubernetes metadata collected by Kentik's network observability
+agent.
+
+Examples: `src_pod`, `dst_namespace`, `src_workload`, `dst_node`
+
+**Use cases:**
+- Which pods are generating the most egress traffic?
+- Which namespaces have the highest inter-cluster traffic?
+- East-west traffic breakdown by workload
+
+---
+
+### OTT (Over-The-Top Streaming)
+
+Group traffic by streaming service or content provider classifications.
+
+Examples: `src_ott_provider`, `dst_ott_service`, `ott_content_type`
+
+**Use cases:**
+- How much bandwidth is consumed by streaming services?
+- Which OTT providers are driving the most traffic on your network?
+
+---
+
+### Kappa (Process-Aware Telemetry)
+
+Group traffic by process-level metadata from Kentik's eBPF-based agent.
+
+Examples: `src_process_name`, `src_container_id`, `src_workload_name`,
+`src_workload_namespace`
+
+**Use cases:**
+- Which processes are responsible for specific traffic flows?
+- Container-level traffic attribution
+
+---
+
+### OCI (Oracle Cloud Infrastructure)
+
+Group traffic by OCI resource metadata for traffic attribution within Oracle
+Cloud environments.
+
+---
+
+### Extended SNMP / Streaming Telemetry
+
+Expanded set of SNMP and streaming telemetry dimensions including interface
+counters, device-level metrics, and vendor-specific fields.
+
+---
+
+### Vendor-Specific
+
+Dimensions specific to network equipment vendors, including custom fields
+exported by certain router and switch platforms.
+
+---
+
+## Bundled Dashboards
+
+v2.0.0 ships with four dashboards provisioned automatically in a "Kentik" folder.
+
+### Kentik Home
+A starting-point overview showing top traffic by source AS, destination country,
+and protocol. Good entry point for network-wide visibility.
+
+### Top Talkers
+Identifies highest-volume sources and destinations across IPs, ASNs, ports, and
+protocols. Useful for capacity planning and abuse detection.
+
+### OSI Health
+Layer-by-layer network health covering L3 (IP), L4 (TCP/UDP), and
+application-layer metrics. Surfaces retransmits, latency indicators, and traffic
+anomalies.
+
+### Site Overview
+Per-site traffic breakdown showing inbound and outbound volume by site, with
+device-level drill-down.
+
+---
+
+## Field Team Notes
+
+### Positioning
+
+Lead with **performance** (batch scheduler = faster dashboards) and **portal
+integration** (deep-link = no context switching). These are immediately visible
+and demo well.
+
+The expanded dimension library is the key conversation for:
+- **Kubernetes customers** — pod/namespace/workload traffic attribution
+- **OTT/media customers** — streaming service bandwidth analysis
+- **Cloud customers** — OCI, extended AWS/Azure/GCP dimensions
+
+---
+
+### Qualification Checklist
+
+Before recommending v2.0.0, confirm:
+
+- [ ] Grafana version 11.6 or later — **hard requirement, no workaround**
+- [ ] Customer has a Kentik account with API access
+- [ ] Warn about dashboard migration if they have existing v1.7.0 dashboards
+- [ ] EU customers: confirm region setting in datasource config
+- [ ] Multi-panel dashboards: highlight the batch scheduler benefit
+
+---
+
+### Known Limitations
+
+- Maximum 8 dimensions per query
+- Conjunction operator (AND/OR) applies globally to all filters — mixed AND/OR
+  within a single query is not supported
+- Overlay mode is supported in the query model but not yet exposed in the UI
+
+---
+
+### Demo Flow (15 minutes)
+
+1. Open a dashboard with 5+ panels — show load time vs a v1.7.0 equivalent
+2. Click the portal deep-link on a panel — show the same query in Kentik
+3. Edit a panel — show the Alias By autocomplete and filter builder
+4. Toggle Data Mode to Table — show the Top-N summary view
+5. For Kubernetes accounts: add a `src_pod` or `dst_namespace` dimension
+
+---
+
+### Support
+
+- **Issues:** [github.com/kentik/kentik-grafana-app/issues](https://github.com/kentik/kentik-grafana-app/issues)
+- **Grafana catalog / signing questions:** integrations@grafana.com

--- a/provisioning/dashboards/dashboards.yaml
+++ b/provisioning/dashboards/dashboards.yaml
@@ -10,4 +10,4 @@ providers:
     allowUiUpdates: true
     updateIntervalSeconds: 600
     options:
-      path: /root/kentik-datasource/dashboards
+      path: /root/kentik-connect-datasource/dashboards

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -2,8 +2,8 @@ apiVersion: 1
 
 datasources:
   - name: 'Kentik'
-    type: 'kentik-datasource'
-    uid: 'kentik-datasource-dev'
+    type: 'kentik-connect-datasource'
+    uid: 'kentik'
     access: proxy
     isDefault: false
     orgId: 1

--- a/scripts/build-signed.sh
+++ b/scripts/build-signed.sh
@@ -14,11 +14,15 @@
 #   GRAFANA_ACCESS_POLICY_TOKEN   (required) Grafana Cloud access policy token for signing
 #
 # Output:
-#   kentik-datasource-<version>.zip
+#   kentik-connect-datasource-<version>.zip
 #
 set -euo pipefail
 
-PLUGIN_ID="kentik-datasource"
+PLUGIN_ID="$(node -e "process.stdout.write(require('./src/plugin.json').id)")"
+if [[ -z "$PLUGIN_ID" ]]; then
+  echo "Error: could not read plugin ID from src/plugin.json" >&2
+  exit 1
+fi
 VERSION="dev"
 SIGN_ARGS=()
 

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -3,7 +3,7 @@ import { JsonData, MyDataSourceOptions, MySecureJsonData, Region, Url } from './
 import { css } from '@emotion/css';
 import { GrafanaTheme2, SelectableValue, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-import { Input, SecretInput, Button, Field, FieldSet, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Input, SecretInput, Button, Field, FieldSet, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
 import { showCustomAlert } from './utils/alert_helper';
 import { KentikAPI } from './datasource/kentik_api';
 
@@ -72,15 +72,31 @@ export function ConfigEditor(props: Props) {
     return getUrlByRegion(region, state.dynamicUrl);
   };
 
-  const onChangeEmail = (e: ChangeEvent<HTMLInputElement>) => setState({ ...state, email: e.target.value.trim() });
+  const onChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {
+    const email = e.target.value.trim();
+    setState({ ...state, email });
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, email } });
+  };
   const onChangeCustomUrl = (e: ChangeEvent<HTMLInputElement>) => {
     const newUrl = e.target.value.trim();
-    setState({ ...state, dynamicUrl: newUrl, url: getUrlByRegion(Region.CUSTOM, newUrl) });
+    const url = getUrlByRegion(Region.CUSTOM, newUrl);
+    setState({ ...state, dynamicUrl: newUrl, url });
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, dynamicUrl: newUrl, url } });
   };
-  const onChangeRegion = (region: Region) => setState({ ...state, region, url: _getUrlByRegion(region), dynamicUrl: '' });
-  const onChangeToken = (e: ChangeEvent<HTMLInputElement>) => setState({ ...state, token: e.target.value.trim() });
-  const onResetToken = () =>
+  const onChangeRegion = (region: Region) => {
+    const url = _getUrlByRegion(region);
+    setState({ ...state, region, url, dynamicUrl: '' });
+    onOptionsChange({ ...options, jsonData: { ...options.jsonData, region, url, dynamicUrl: '' } });
+  };
+  const onChangeToken = (e: ChangeEvent<HTMLInputElement>) => {
+    const token = e.target.value.trim();
+    setState({ ...state, token });
+    onOptionsChange({ ...options, secureJsonData: { token } });
+  };
+  const onResetToken = () => {
     setState({ ...state, token: '', tokenSet: false, apiValidated: false, apiMemberWarning: false, apiError: false });
+    onOptionsChange({ ...options, secureJsonFields: { ...options.secureJsonFields, token: false }, secureJsonData: {} });
+  };
 
   const _onApiError = () => setState({ ...state, apiValidated: false, apiError: true });
 
@@ -146,7 +162,6 @@ export function ConfigEditor(props: Props) {
       showCustomAlert('Settings saved!', '', 'success');
       setTimeout(() => window.location.reload(), 800);
     } catch (err: any) {
-      console.error('Failed to save datasource config:', err);
       const msg = err?.data?.message || 'Unknown error';
       showCustomAlert(`Error saving settings: ${msg}`, '', 'error');
     } finally {
@@ -178,13 +193,12 @@ export function ConfigEditor(props: Props) {
         </Field>
 
         {isConfigured() && state.apiError && (
-          <div className="gf-form">
-            <i className={`fa fa-exclamation-circle ${s.colorError}`}>
-              <span className={s.marginLeft}>
-                Invalid API credentials. This app won&apos;t work until the credentials are updated.
-              </span>
-            </i>
-          </div>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <i className={`fa fa-exclamation-circle ${s.colorError}`} />
+            <span className={s.marginLeft}>
+              Invalid API credentials. This app won&apos;t work until the credentials are updated.
+            </span>
+          </Stack>
         )}
 
         {state.tokenSet && state.apiValidated && (

--- a/src/datasource/DataSource.ts
+++ b/src/datasource/DataSource.ts
@@ -259,12 +259,10 @@ export class DataSource extends DataSourceApi<Query, MyDataSourceOptions> {
       return { response: { data: [] } };
     }
 
-    const customDimensions = await this.kentik.getCustomDimensions().catch((err: any) => {
-      console.warn('[KentikDS] Failed to load custom dimensions, continuing without them:', err.message || err);
+    const customDimensions = await this.kentik.getCustomDimensions().catch((_err: any) => {
       return [];
     });
-    const savedFiltersList = await this.kentik.getSavedFilters().catch((err: any) => {
-      console.warn('[KentikDS] Failed to load saved filters, continuing without them:', err.message || err);
+    const savedFiltersList = await this.kentik.getSavedFilters().catch((_err: any) => {
       return [];
     });
     const kentikFilters: AdHocVariableFilter[] = options.filters || [];
@@ -456,8 +454,7 @@ export class DataSource extends DataSourceApi<Query, MyDataSourceOptions> {
         const allAggResults = await Promise.all(aggPromises);
         return _.flatten(allAggResults);
         } catch (err: any) {
-          console.error('[KentikDS] Query target error:', err);
-          return [];
+          throw err;
         }
       }
     );
@@ -684,9 +681,7 @@ export class DataSource extends DataSourceApi<Query, MyDataSourceOptions> {
         }
       }
 
-      // Debug: log when a tag fails to resolve so we can inspect the series row
-      console.warn(`[KentikDS] Alias tag {{${tagName}}} not found in series row. Available keys:`, Object.keys(series).filter((k) => k !== 'timeSeries'));
-
+      // Tag not found — return the original token unchanged
       return match;
     };
 

--- a/src/datasource/QueryEditor.tsx
+++ b/src/datasource/QueryEditor.tsx
@@ -229,7 +229,6 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
           customDimensions
         });
       } catch (error) {
-        console.error('Failed to initialize Query Editor:', error);
         setState(s => ({ ...s, isLoading: false, isDevicesLoading: false }));
       }
     };
@@ -500,8 +499,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       return;
     }
     const query: Query = _.cloneDeep(props.query);
-    // @ts-ignore
-    query[field] = option.value;
+    (query as Record<keyof Query, unknown>)[field] = option.value;
 
     onQueryChange(query);
     const queryValid = isQueryValid(query);
@@ -515,8 +513,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       return;
     }
     const query = _.cloneDeep(props.query);
-    //@ts-ignore
-    query[field] = value;
+    (query as Record<keyof Query, unknown>)[field] = value;
 
     onQueryChange(query);
     isQueryValid(query)
@@ -524,8 +521,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
 
   const onDeviceSelect = (value: SelectableValue[]) => {
     const query: Query = _.cloneDeep(props.query);
-    // @ts-ignore
-    query['devices'] = value;
+    query['devices'] = value as Query['devices'];
 
     onQueryChange(query);
     isQueryValid(query)
@@ -533,7 +529,6 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
 
   const onMetricSelect = (value: SelectableValue[]) => {
     const query: Query = _.cloneDeep(props.query);
-    // @ts-ignore
     query['metric'] = value;
 
     onQueryChange(query);
@@ -576,14 +571,10 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       const addedDim = findDim(addedId);
 
       if (removedDim && addedDim) {
-        // @ts-ignore
-        let removedField = removedDim['field'];
-        // @ts-ignore
-        let addedField = addedDim['field'];
-        // @ts-ignore
-        let removedText = removedDim['text'];
-        // @ts-ignore
-        let addedText = addedDim['text'];
+        let removedField = (removedDim as ComboboxOption & { field?: string; text?: string })['field'];
+        let addedField = (addedDim as ComboboxOption & { field?: string; text?: string })['field'];
+        let removedText = (removedDim as ComboboxOption & { field?: string; text?: string })['text'];
+        let addedText = (addedDim as ComboboxOption & { field?: string; text?: string })['text'];
 
         // Handle variables (which don't have field/text properties but value starts with $)
         if (!removedField && removedDim.value?.toString().startsWith('$')) {
@@ -624,8 +615,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
     }
 
     const query: Query = _.cloneDeep(props.query);
-    // @ts-ignore
-    query['dimension'] = value;
+    query['dimension'] = value as Query['dimension'];
 
     if (newAliasBy !== props.query.aliasBy) {
       query.aliasBy = newAliasBy;

--- a/src/datasource/kentik_api.ts
+++ b/src/datasource/kentik_api.ts
@@ -218,7 +218,6 @@ export class BatchQueryScheduler {
     return new Promise((resolve, reject) => {
       const bucket = `batch_${++batchCounter}`;
       this.pending.push({ bucket, query, resolve, reject });
-      console.log(`[KentikDS] BatchScheduler: queued ${bucket} (${this.pending.length} pending, dim=${query.dimension?.[0] || '?'})`);
 
       // Reset the flush timer — new query extends the window
       if (this.timer) {
@@ -243,7 +242,6 @@ export class BatchQueryScheduler {
       chunks.push(all.slice(i, i + MAX_QUERIES_PER_BATCH));
     }
 
-    console.log(`[KentikDS] BatchScheduler: flushing ${all.length} queries in ${chunks.length} chunk(s) of max ${MAX_QUERIES_PER_BATCH}`);
     await Promise.all(chunks.map((chunk) => this.executeChunk(chunk)));
   }
 
@@ -271,7 +269,6 @@ export class BatchQueryScheduler {
       }
     } catch (_err) {
       // Sub-batch failed — fall back to individual queries for this chunk
-      console.warn(`[KentikDS] Batch query to ${this.endpoint} failed, falling back to individual queries`);
       await this.fallbackIndividual(chunk);
     }
   }

--- a/src/datasource/query_builder.ts
+++ b/src/datasource/query_builder.ts
@@ -165,13 +165,6 @@ function buildTopXdataQuery(options: any, panelId?: string) {
   const metricArray = options.metric?.split(',').map(normaliseKtPrefix);
   const metricDefs = allMetricOptions.filter(opt => metricArray?.includes(opt.value));
 
-  console.log('[KentikDS] buildTopXdataQuery debug:', {
-    rawMetric: options.metric,
-    metricArray,
-    metricDefsCount: metricDefs.length,
-    rawDimension: options.dimension,
-  });
-
   if (_.isEmpty(options.deviceNames)) {
     // No devices selected → query all devices (same pattern as sites)
   }

--- a/src/datasource/validation/validate-core.ts
+++ b/src/datasource/validation/validate-core.ts
@@ -212,8 +212,7 @@ export async function sendTopXDataQuery(
   datasourceUid: string,
   apiKey: string,
   query: any,
-  maxRetries = 3,
-  quiet = true
+  maxRetries = 3
 ): Promise<{ ok: boolean; status: number; body: any }> {
   const url = `${grafanaUrl}/api/datasources/proxy/uid/${datasourceUid}/api/v5/query/topXdata`;
 
@@ -239,9 +238,6 @@ export async function sendTopXDataQuery(
     } catch (err: any) {
       if (attempt < maxRetries) {
         const backoff = Math.min(2000 * Math.pow(2, attempt), 30000);
-        if (!quiet) {
-          console.log(`    ⟳ fetch failed, retrying in ${backoff}ms (attempt ${attempt + 1}/${maxRetries})...`);
-        }
         await sleep(backoff);
         continue;
       }
@@ -255,13 +251,6 @@ export async function sendTopXDataQuery(
         : resp.status === 429
         ? Math.min(5000 * Math.pow(2, attempt), 60000)
         : Math.min(2000 * Math.pow(2, attempt), 15000);
-      if (!quiet) {
-        console.log(
-          `    ⟳ ${resp.status} ${
-            resp.status === 429 ? 'rate limited' : 'bad gateway'
-          }, retrying in ${backoff}ms (attempt ${attempt + 1}/${maxRetries})...`
-        );
-      }
       await sleep(backoff);
       continue;
     }
@@ -285,12 +274,11 @@ export async function validateDimension(
   dim: DimensionLike,
   metric: MetricLike,
   config: { grafanaUrl: string; datasourceUid: string; apiKey: string; device: string | null },
-  quiet = true
 ): Promise<ValidationResult> {
   const start = Date.now();
   try {
     const query = buildMinimalQuery(dim.value, metric, config.device);
-    const resp = await sendTopXDataQuery(config.grafanaUrl, config.datasourceUid, config.apiKey, query, 3, quiet);
+    const resp = await sendTopXDataQuery(config.grafanaUrl, config.datasourceUid, config.apiKey, query, 3);
 
     const durationMs = Date.now() - start;
     const status = resp.ok ? 'pass' : 'fail';

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "Kentik",
-  "id": "kentik-datasource",
+  "id": "kentik-connect-datasource",
   "metrics": true,
   "info": {
     "description": "Visualize and explore Kentik network observability data in Grafana.",
@@ -26,7 +26,8 @@
     },
     "links": [
       {"name": "Kentik", "url": "https://www.kentik.com"},
-      {"name": "Documentation", "url": "https://kb.kentik.com/docs/apis-overview"}
+      {"name": "Documentation", "url": "https://kb.kentik.com/docs/apis-overview"},
+      {"name": "sponsor", "url": "https://www.kentik.com/get-started/"}
     ],
     "screenshots": [
       {"name": "Query Editor", "path": "img/queryeditor.png"},


### PR DESCRIPTION
## Summary

Resolves all errors and warnings from the Grafana plugin validator that were blocking submission of v2.0.0.

## Changes

- **Plugin ID** renamed to `kentik-connect-datasource` — Grafana enforces that datasource plugins must end in `-datasource`
- **Removed** all `console.*` logging, `@ts-ignore`, and deprecated `gf-form` CSS from shipped source
- **Dashboard datasource UIDs** cleaned up — removed `-dev` suffix, use fixed `uid: kentik` matching provisioning
- **Home dashboard** logo switched from external grafana.com URL to local plugin asset
- **Sponsorship link** added to `plugin.json` (`https://www.kentik.com/get-started/`)
- **CI** validator split into a separate job with a clean checkout (no `node_modules`) so semgrep doesn't scan dependency source files
- **`build-signed.sh`** now derives plugin ID from `src/plugin.json` instead of hardcoding it
- **API errors** (custom dimensions, saved filters, query failures) now surfaced via Grafana `appEvents` instead of being silently swallowed
- **CHANGELOG** corrected — 2021 entry had wrong target ID for that rename
- **README and release docs** updated with accurate migration guidance for users of `kentik-connect-app` v1.7.0

## Notes for reviewer

This supersedes `kentik-connect-app` (v1.7.0, type: `app`). Both plugins can coexist on the same Grafana instance — existing v1.7.0 dashboards remain functional while users migrate at their own pace. We will contact `integrations@grafana.com` to request a deprecation banner on the old catalog entry once this is merged and released.