### PR TITLE
Fix Grafana plugin review feedback

### DIFF
--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -3,7 +3,7 @@ import { JsonData, MyDataSourceOptions, MySecureJsonData, Region, Url } from './
 import { css } from '@emotion/css';
 import { GrafanaTheme2, SelectableValue, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { getBackendSrv } from '@grafana/runtime';
-import { Input, SecretInput, Button, Field, FieldSet, RadioButtonGroup, Stack, useStyles2 } from '@grafana/ui';
+import { Input, SecretInput, Button, Field, FieldSet, RadioButtonGroup, Stack, useStyles2, Icon } from '@grafana/ui';
 import { showCustomAlert } from './utils/alert_helper';
 import { KentikAPI } from './datasource/kentik_api';
 
@@ -194,7 +194,7 @@ export function ConfigEditor(props: Props) {
 
         {isConfigured() && state.apiError && (
           <Stack direction="row" alignItems="center" gap={1}>
-            <i className={`fa fa-exclamation-circle ${s.colorError}`} />
+            <Icon name="exclamation-circle" className={s.colorError} />
             <span className={s.marginLeft}>
               Invalid API credentials. This app won&apos;t work until the credentials are updated.
             </span>
@@ -202,25 +202,29 @@ export function ConfigEditor(props: Props) {
         )}
 
         {state.tokenSet && state.apiValidated && (
-          <div className="kentik-enabled-box">
-            <i className="icon-gf icon-gf-check kentik-api-status-icon success"></i>
-            <span className={s.marginLeft}>
-              Successfully enabled.
-              <strong> Next up: </strong>
-              <a href="d/xScUGST71/kentik-home" className="external-link">
-                Go to Kentik Home Dashboard
-              </a>
-            </span>
+          <div className={s.statusBox}>
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Icon name="check-circle" className={s.colorSuccess} />
+              <span className={s.marginLeft}>
+                Successfully enabled.
+                <strong> Next up: </strong>
+                <a href="d/xScUGST71/kentik-home" className="external-link">
+                  Go to Kentik Home Dashboard
+                </a>
+              </span>
+            </Stack>
           </div>
         )}
 
         {state.tokenSet && state.apiValidated && state.apiMemberWarning && (
-          <div className="kentik-enabled-box">
-            <i className="fa fa-warning kentik-api-status-icon warning"></i>
-            <span className={s.marginLeft}>
-              The specified Kentik user seems to have Member access level (not Admin), Custom Dimensions in the
-              dashboard filters won&apos;t be available.
-            </span>
+          <div className={s.statusBox}>
+            <Stack direction="row" alignItems="center" gap={1}>
+              <Icon name="exclamation-triangle" className={s.colorWarning} />
+              <span className={s.marginLeft}>
+                The specified Kentik user seems to have Member access level (not Admin), Custom Dimensions in the
+                dashboard filters won&apos;t be available.
+              </span>
+            </Stack>
           </div>
         )}
 
@@ -241,6 +245,18 @@ export function ConfigEditor(props: Props) {
 const getStyles = (theme: GrafanaTheme2) => ({
   colorError: css`
     color: ${theme.colors.error.text};
+  `,
+  colorSuccess: css`
+    color: ${theme.colors.success.text};
+  `,
+  colorWarning: css`
+    color: ${theme.colors.warning.text};
+  `,
+  statusBox: css`
+    margin-top: ${theme.spacing(1)};
+    padding: ${theme.spacing(1)};
+    background: ${theme.colors.background.secondary};
+    border-radius: ${theme.shape.radius.default};
   `,
   marginTop: css`
     margin-top: ${theme.spacing(1)};

--- a/src/datasource/QueryEditor.tsx
+++ b/src/datasource/QueryEditor.tsx
@@ -1,10 +1,11 @@
 import { ALL_DEVICES_LABEL, ALL_SITES_LABEL, DataSource } from './DataSource';
-import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { Stack, Input, Button, Field, Label, Combobox, ComboboxOption, MultiCombobox, FieldValidationMessage } from '@grafana/ui';
+import { GrafanaTheme2, QueryEditorProps, SelectableValue } from '@grafana/data';
+import { Stack, Input, Button, Field, Label, Combobox, ComboboxOption, MultiCombobox, FieldValidationMessage, useStyles2 } from '@grafana/ui';
 import { getTemplateSrv } from '@grafana/runtime';
 import { DataQuery } from '@grafana/schema';
 import React, { useEffect, useState, useRef } from 'react';
 import _ from 'lodash';
+import { css } from '@emotion/css';
 import { dimensionList, DimensionCategory } from './metric_def';
 import { DimensionClass } from './metric_types';
 
@@ -104,6 +105,7 @@ const OBLIGATORY_FIELDS_NAMES = ['sites', 'dimension', 'metric'];
 export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
   _.defaults(props.query, DEFAULT_QUERY);
 
+  const s = useStyles2(getQueryEditorStyles);
   const prefixInputRef = useRef<HTMLInputElement>(null);
   const aliasInputRef = useRef<HTMLInputElement>(null);
 
@@ -1023,7 +1025,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
         </Field>
       </Stack>
       <Stack direction="row" gap={2} alignItems="flex-start">
-        <Field label={<><span>Sites <span style={{ color: 'red' }}>*</span></span></>}>
+        <Field label={<><span>Sites <span className={s.requiredIndicator}>*</span></span></>}>
           <>
             <MultiCombobox<string>
               placeholder={state.isLoading ? 'Loading...' : ALL_SITES_LABEL}
@@ -1051,7 +1053,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
         </Field>
       </Stack>
       <Stack direction="row" gap={2} alignItems="flex-start">
-        <Field label={<><span>Dimensions <span style={{ color: 'red' }}>*</span></span></>}>
+        <Field label={<><span>Dimensions <span className={s.requiredIndicator}>*</span></span></>}>
           <>
             <MultiCombobox<string>
               placeholder={'Select...'}
@@ -1061,11 +1063,11 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
               width={40}
               onChange={(value: Array<ComboboxOption<string>>) => onDimensionSelect(value)}
             />
-            {ensureArray(props.query.dimension).length >= MAX_DIMENSIONS && <div style={{ width: '150px' }}>Max {MAX_DIMENSIONS} dimensions allowed.</div>}
+            {ensureArray(props.query.dimension).length >= MAX_DIMENSIONS && <div className={s.dimensionLimitMessage}>Max {MAX_DIMENSIONS} dimensions allowed.</div>}
             {errorState.dimension && <FieldValidationMessage>{errorState.dimension}</FieldValidationMessage>}
           </>
         </Field>
-        <Field label={<><span>Metric <span style={{ color: 'red' }}>*</span></span></>}>
+        <Field label={<><span>Metric <span className={s.requiredIndicator}>*</span></span></>}>
           <>
             <MultiCombobox<string>
               placeholder={state.isDevicesLoading ? 'Loading...' : 'Select...'}
@@ -1164,7 +1166,7 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       </Stack>
       {props.query.customFilters.map((filter: CustomFilter, filterIdx: number) => (
         <Stack direction="column" gap={0.5} key={`custom-filter-stack-${filterIdx}`}>
-          <div style={{ height: '8px' }} />
+          <div className={s.filterSpacer} />
           <Stack direction="row" gap={2} alignItems="center" key={`custom-filter-row-${filterIdx}`}>
             <Combobox
               value={filter.keySegment}
@@ -1220,6 +1222,7 @@ type DimensionsSuggestionComponentProps = {
 
 const DimensionsSuggestionComponent = (props: DimensionsSuggestionComponentProps) => {
 
+  const s = useStyles2(getQueryEditorStyles);
   const { aliasSuggestionFilter, showAliasSuggestions, activeSuggestionField, activeSuggestionIndex, aliasTagOptions, onSelectAliasSuggestion, field } = props;
   if (!showAliasSuggestions || activeSuggestionField !== field) {
     return null;
@@ -1248,68 +1251,106 @@ const DimensionsSuggestionComponent = (props: DimensionsSuggestionComponentProps
   });
 
   return (
-    <div style={{
-      position: 'absolute',
-      top: '100%',
-      left: 0,
-      zIndex: 1000,
-      backgroundColor: 'var(--background-primary, #111)',
-      border: '1px solid var(--border-medium, #333)',
-      borderRadius: '4px',
-      maxHeight: '280px',
-      overflowY: 'auto',
-      minWidth: '300px',
-      boxShadow: '0 4px 8px rgba(0,0,0,0.3)',
-    }}>
+    <div className={s.suggestionDropdown}>
       {filteredSuggestions.map((opt, idx) => {
         const prevGroup = idx > 0 ? filteredSuggestions[idx - 1].group : undefined;
         const showGroupHeader = opt.group && opt.group !== prevGroup;
         return (
           <React.Fragment key={`${opt.group || ''}-${opt.value || idx}`}>
             {showGroupHeader && (
-              <div style={{
-                padding: '6px 12px 4px',
-                fontSize: '11px',
-                fontWeight: 600,
-                textTransform: 'uppercase',
-                letterSpacing: '0.05em',
-                color: 'var(--text-secondary, #8e8e8e)',
-                borderTop: idx > 0 ? '1px solid var(--border-weak, #222)' : 'none',
-              }}>
+              <div className={idx > 0 ? `${s.suggestionGroupHeader} ${s.suggestionGroupBorder}` : s.suggestionGroupHeader}>
                 {opt.group}
               </div>
             )}
             <div
-              style={{
-                padding: '6px 12px',
-                cursor: 'pointer',
-                backgroundColor: idx === activeSuggestionIndex ? 'var(--background-secondary, #222)' : 'transparent',
-              }}
+              className={idx === activeSuggestionIndex ? `${s.suggestionItem} ${s.suggestionItemActive}` : s.suggestionItem}
               onMouseDown={(e) => {
                 e.preventDefault(); // Prevent blur
                 onSelectAliasSuggestion(opt);
               }}
               onMouseEnter={(e) => {
-                (e.target as HTMLDivElement).style.backgroundColor = 'var(--background-secondary, #222)';
+                (e.currentTarget as HTMLDivElement).classList.add(s.suggestionItemActive);
               }}
               onMouseLeave={(e) => {
-                (e.target as HTMLDivElement).style.backgroundColor = 'transparent';
+                if (idx !== activeSuggestionIndex) {
+                  (e.currentTarget as HTMLDivElement).classList.remove(s.suggestionItemActive);
+                }
               }}
             >
-              <div style={{ fontWeight: 500 }}>{opt.label}</div>
+              <div className={s.suggestionLabel}>{opt.label}</div>
               {opt.description && (
-                <div style={{ fontSize: '11px', opacity: 0.6 }}>{opt.description}</div>
+                <div className={s.suggestionDescription}>{opt.description}</div>
               )}
-              <div style={{ fontSize: '11px', opacity: 0.7 }}>{opt.value}</div>
+              <div className={s.suggestionValue}>{opt.value}</div>
             </div>
           </React.Fragment>
         );
       })}
       {filteredSuggestions.length === 0 && (
-        <div style={{ padding: '8px 12px', opacity: 0.6 }}>
+        <div className={s.suggestionEmpty}>
           No matching tags. Select dimensions first.
         </div>
       )}
     </div>
   );
 }
+
+const getQueryEditorStyles = (theme: GrafanaTheme2) => ({
+  requiredIndicator: css`
+    color: ${theme.colors.error.text};
+  `,
+  filterSpacer: css`
+    height: ${theme.spacing(1)};
+  `,
+  dimensionLimitMessage: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    color: ${theme.colors.text.secondary};
+  `,
+  suggestionDropdown: css`
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: ${theme.zIndex.dropdown};
+    background-color: ${theme.colors.background.primary};
+    border: 1px solid ${theme.colors.border.medium};
+    border-radius: ${theme.shape.radius.default};
+    max-height: 280px;
+    overflow-y: auto;
+    min-width: 300px;
+    box-shadow: ${theme.shadows.z3};
+  `,
+  suggestionGroupHeader: css`
+    padding: ${theme.spacing(0.75)} ${theme.spacing(1.5)} ${theme.spacing(0.5)};
+    font-size: ${theme.typography.bodySmall.fontSize};
+    font-weight: ${theme.typography.fontWeightBold};
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: ${theme.colors.text.secondary};
+  `,
+  suggestionGroupBorder: css`
+    border-top: 1px solid ${theme.colors.border.weak};
+  `,
+  suggestionItem: css`
+    padding: ${theme.spacing(0.75)} ${theme.spacing(1.5)};
+    cursor: pointer;
+    background-color: transparent;
+  `,
+  suggestionItemActive: css`
+    background-color: ${theme.colors.background.secondary};
+  `,
+  suggestionLabel: css`
+    font-weight: ${theme.typography.fontWeightMedium};
+  `,
+  suggestionDescription: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    opacity: 0.6;
+  `,
+  suggestionValue: css`
+    font-size: ${theme.typography.bodySmall.fontSize};
+    opacity: 0.7;
+  `,
+  suggestionEmpty: css`
+    padding: ${theme.spacing(1)} ${theme.spacing(1.5)};
+    opacity: 0.6;
+  `,
+});

--- a/src/datasource/tests/kentik_proxy.test.ts
+++ b/src/datasource/tests/kentik_proxy.test.ts
@@ -1,5 +1,7 @@
 import { KentikAPI } from '../kentik_api';
 import { KentikProxy } from '../kentik_proxy';
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe('KentikProxy', () => {
   const ctx: any = {};
@@ -73,3 +75,97 @@ function getKentikProxyInstance(ctx: any, data: any) {
   ctx.kentikAPI = new KentikAPI(ctx.backendSrv, 'uid');
   ctx.kentikProxy = new KentikProxy(ctx.kentikAPI);
 }
+
+// ── plugin.json proxy route hygiene ───────────────────────────────────────
+// Guards against the leading-slash route path bug that caused 502 errors on
+// Grafana 11.x (the proxy regex strips the leading slash from proxyPath, so
+// route paths with a leading slash never match `strings.HasPrefix`).
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+const SRC_ROOT = path.resolve(REPO_ROOT, 'src');
+
+function readSource(relPath: string): string {
+  return fs.readFileSync(path.resolve(SRC_ROOT, relPath), 'utf-8');
+}
+
+function readPluginJson(): any {
+  return JSON.parse(readSource('plugin.json'));
+}
+
+describe('plugin.json proxy route hygiene', () => {
+  const plugin = readPluginJson();
+  const routes: Array<{ path: string; url: string; method: string }> = plugin.routes || [];
+
+  it('route paths must not start with a leading slash', () => {
+    const violations = routes
+      .filter((r) => r.path.startsWith('/'))
+      .map((r) => `path "${r.path}" starts with /`);
+    expect(violations).toEqual([]);
+  });
+
+  it('route paths must be unique', () => {
+    const paths = routes.map((r) => r.path);
+    const duplicates = paths.filter((p, i) => paths.indexOf(p) !== i);
+    expect(duplicates).toEqual([]);
+  });
+
+  it('every route must include auth headers', () => {
+    const violations = routes
+      .filter((r: any) => {
+        const headers: Array<{ name: string }> = r.headers || [];
+        return !headers.some((h) => h.name === 'X-CH-Auth-API-Token');
+      })
+      .map((r) => `route "${r.path}" missing X-CH-Auth-API-Token header`);
+    expect(violations).toEqual([]);
+  });
+
+  it('kentik_api.ts request URLs must match a declared route path', () => {
+    const apiSource = readSource('datasource/kentik_api.ts');
+
+    const addPrefixes = (url: string, set: Set<string>) => {
+      const normalized = url.startsWith('/') ? url.slice(1) : url;
+      const segments = normalized.split('/');
+      if (segments[0]) { set.add(segments[0]); }
+      if (segments.length > 1 && segments[1]) {
+        set.add(segments[0] + '/' + segments[1]);
+      }
+    };
+
+    const usedPrefixes = new Set<string>();
+
+    // Direct calls: this._get('/device/...'), this._post('/api/v5/...')
+    const directPattern = /this\._(?:get|post|put)\(\s*['"`]\/([^'"`]+)['"]/g;
+    let match: RegExpExecArray | null;
+    while ((match = directPattern.exec(apiSource)) !== null) {
+      addPrefixes(match[1], usedPrefixes);
+    }
+
+    // Indirect URLs: string literals like '/api/v5/query/topXdata' passed
+    // to constructors (e.g. BatchQueryScheduler) that ultimately call _post
+    const indirectPattern = /new\s+\w+\([^)]*['"`](\/[a-z][^'"`]+)['"`]/g;
+    while ((match = indirectPattern.exec(apiSource)) !== null) {
+      addPrefixes(match[1], usedPrefixes);
+    }
+
+    // Keep only the most specific prefix (e.g. "api/v5" not "api")
+    const specificPrefixes = new Set<string>();
+    for (const prefix of usedPrefixes) {
+      const hasMoreSpecific = [...usedPrefixes].some(
+        (other) => other !== prefix && other.startsWith(prefix + '/')
+      );
+      if (!hasMoreSpecific) {
+        specificPrefixes.add(prefix);
+      }
+    }
+
+    const routePaths = new Set(routes.map((r) => r.path));
+    const unmatched: string[] = [];
+    for (const prefix of specificPrefixes) {
+      const hasRoute = [...routePaths].some((rp) => rp === prefix || prefix.startsWith(rp));
+      if (!hasRoute) {
+        unmatched.push(`API prefix "${prefix}" has no matching route in plugin.json`);
+      }
+    }
+    expect(unmatched).toEqual([]);
+  });
+});

--- a/src/datasource/tests/metric_dimension_integrity.test.ts
+++ b/src/datasource/tests/metric_dimension_integrity.test.ts
@@ -15,6 +15,8 @@
 
 import { dimensionList, allMetricOptions, metricNestedList, flattenMetricOptions } from '../metric_def';
 import { DimensionCategory } from '../metric_types';
+import * as fs from 'fs';
+import * as path from 'path';
 
 // -- Helpers ----------------------------------------------------------------
 
@@ -237,5 +239,101 @@ describe('No Legacy Prefixes', () => {
         m.value.includes('st_interface_metrics') || m.unit?.includes('st_interface_metrics')
     );
     expect(wrong.map((m) => m.value)).toEqual([]);
+  });
+});
+
+// ── UI Theming Hygiene ────────────────────────────────────────────────────
+// Guards against inline styles and legacy CSS classes that don't adapt to
+// Grafana's light/dark themes.  Caught during the Grafana plugin review.
+
+const SRC_ROOT = path.resolve(__dirname, '..', '..');
+
+function readSource(relPath: string): string {
+  return fs.readFileSync(path.resolve(SRC_ROOT, relPath), 'utf-8');
+}
+
+describe('QueryEditor theming hygiene', () => {
+  const source = readSource('datasource/QueryEditor.tsx');
+
+  it('must not use hardcoded color values in inline styles', () => {
+    // Catches color, backgroundColor, borderColor with named colors or hex values
+    const pattern = /style=\{\{[^}]*(?:(?:background|border)?[Cc]olor:\s*['"](?:red|blue|green|white|black|orange|yellow|#[0-9a-fA-F]{3,8})['"])/g;
+    const violations: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      const line = source.substring(0, match.index).split('\n').length;
+      violations.push(`Line ${line}: ${match[0].substring(0, 60)}...`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('must not use hardcoded rgba/rgb in inline styles', () => {
+    // Catches any rgba()/rgb() in style={{...}} blocks
+    const pattern = /style=\{\{[^}]*(?:rgba?\([^)]+\))/g;
+    const violations: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      const line = source.substring(0, match.index).split('\n').length;
+      violations.push(`Line ${line}: ${match[0].substring(0, 60)}...`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('must not use hardcoded font sizes in inline styles', () => {
+    const pattern = /style=\{\{[^}]*fontSize:\s*['"][0-9]+px['"]/g;
+    const violations: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      const line = source.substring(0, match.index).split('\n').length;
+      violations.push(`Line ${line}: ${match[0].substring(0, 60)}...`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('must use useStyles2 for theming', () => {
+    expect(source).toContain('useStyles2');
+  });
+});
+
+describe('ConfigEditor theming hygiene', () => {
+  const source = readSource('ConfigEditor.tsx');
+
+  const BANNED_CSS_CLASSES = [
+    'icon-gf',
+    'icon-gf-check',
+    'kentik-enabled-box',
+    'kentik-enabled-box-inner',
+    'kentik-api-status-icon',
+    'fa fa-warning',
+    'fa fa-check',
+  ];
+
+  it('must not reference legacy or undefined CSS class names', () => {
+    const violations: string[] = [];
+    for (const cls of BANNED_CSS_CLASSES) {
+      if (source.includes(`"${cls}"`) || source.includes(`'${cls}'`)) {
+        violations.push(`Found banned CSS class: "${cls}"`);
+      }
+      if (new RegExp(`className=["'][^"']*\\b${cls.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\b`).test(source)) {
+        violations.push(`Found banned CSS class in className: "${cls}"`);
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('must not use <i> tags with legacy icon classes', () => {
+    const pattern = /<i\s+className=["'][^"']*(?:fa\s|icon-gf)/g;
+    const violations: string[] = [];
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(source)) !== null) {
+      const line = source.substring(0, match.index).split('\n').length;
+      violations.push(`Line ${line}: ${match[0].substring(0, 60)}`);
+    }
+    expect(violations).toEqual([]);
+  });
+
+  it('must use useStyles2 and Icon from @grafana/ui', () => {
+    expect(source).toContain('useStyles2');
+    expect(source).toMatch(/import\s*\{[^}]*Icon[^}]*\}\s*from\s*['"]@grafana\/ui['"]/);
   });
 });

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -89,13 +89,14 @@
       ]
     },
     {
-      "path": "/api/v5",
+      "path": "api/v5",
       "method": "*",
-      "url": "{{.JsonData.url.v5}}",
+      "url": "{{.JsonData.url.v5}}/api/v5",
       "headers": [
         {"name": "X-CH-Auth-API-Token", "content": "{{.SecureJsonData.token}}"},
         {"name": "X-CH-Auth-Email", "content": "{{.JsonData.email}}"},
-        {"name": "Accept", "content": "application/json"}      ]
+        {"name": "Accept", "content": "application/json"}
+      ]
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Addresses three issues from Grafana's plugin review:

- **502 on Grafana 11.6**: Fixed leading slash on `/api/v5` proxy route path that prevented route matching on 11.x
- **Inline styles**: Replaced hardcoded colors, font sizes, and rgba values in QueryEditor with `useStyles2` + theme tokens
- **Legacy CSS classes**: Replaced `kentik-enabled-box`, `icon-gf`, `fa fa-warning` in ConfigEditor with Grafana `Icon` component + themed styles

Tested on Grafana 11.6.0 and 12.4.2. Added regression tests to `kentik_proxy.test.ts` and `metric_dimension_integrity.test.ts`.