### PR TITLE
fix: increase proxy timeout to 30m (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 2.0.1 (2026-04-09)
+
+**Fixes:**
+
+- Increase proxy timeout from 30s to 1800s (30m) to prevent 502 errors on large Kentik accounts
+
 ## 2.0.0 (2026-03-15)
 
 **Features:**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kentik-datasource",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",

--- a/provisioning/datasources/datasources.yml
+++ b/provisioning/datasources/datasources.yml
@@ -11,6 +11,7 @@ datasources:
     editable: true
     jsonData:
       region: 'default'
+      timeout: 1800
       url:
         v6: 'https://grpc.api.kentik.com'
         v5: 'https://api.kentik.com'

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -143,12 +143,20 @@ export function ConfigEditor(props: Props) {
     // Build a minimal payload – only the fields the PUT endpoint needs.
     // Setting version to 0 tells Grafana to skip the optimistic-lock check,
     // which avoids 409 conflicts caused by provisioning version drift.
+    //
+    // timeout: Grafana's data proxy default is 30s, which is too short for
+    // large Kentik accounts. We set 1800s (30m) so queries against accounts
+    // with many devices/interfaces don't hit proxy timeouts.
+    const KENTIK_PROXY_TIMEOUT_SECONDS = 1800;
     const payload: Record<string, any> = {
       name: options.name,
       type: options.type,
       access: options.access,
       uid: options.uid,
-      jsonData: updatedJsonData,
+      jsonData: {
+        ...updatedJsonData,
+        timeout: KENTIK_PROXY_TIMEOUT_SECONDS,
+      },
       version: 0,
       ...(state.token ? { secureJsonData: { token: state.token } } : {}),
     };

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -45,12 +45,15 @@ export function ConfigEditor(props: Props) {
   const s = useStyles2(getStyles);
   const { jsonData, secureJsonFields } = options;
 
+  const KENTIK_PROXY_TIMEOUT_SECONDS = 1800;
+
   const [state, setState] = useState<State>({
     url: jsonData?.url || getUrlByRegion(jsonData?.region, jsonData?.dynamicUrl),
     email: jsonData?.email || '',
     region: jsonData?.region || Region.DEFAULT,
     dynamicUrl: jsonData?.dynamicUrl || '',
     tokenSet: Boolean(jsonData?.tokenSet || secureJsonFields?.token),
+    timeout: jsonData?.timeout ?? KENTIK_PROXY_TIMEOUT_SECONDS,
     token: '',
     apiValidated: false,
     apiMemberWarning: false,
@@ -138,25 +141,18 @@ export function ConfigEditor(props: Props) {
       region: state.region,
       dynamicUrl: state.dynamicUrl,
       tokenSet: !!state.token || state.tokenSet,
+      timeout: KENTIK_PROXY_TIMEOUT_SECONDS,
     };
 
     // Build a minimal payload – only the fields the PUT endpoint needs.
     // Setting version to 0 tells Grafana to skip the optimistic-lock check,
     // which avoids 409 conflicts caused by provisioning version drift.
-    //
-    // timeout: Grafana's data proxy default is 30s, which is too short for
-    // large Kentik accounts. We set 1800s (30m) so queries against accounts
-    // with many devices/interfaces don't hit proxy timeouts.
-    const KENTIK_PROXY_TIMEOUT_SECONDS = 1800;
     const payload: Record<string, any> = {
       name: options.name,
       type: options.type,
       access: options.access,
       uid: options.uid,
-      jsonData: {
-        ...updatedJsonData,
-        timeout: KENTIK_PROXY_TIMEOUT_SECONDS,
-      },
+      jsonData: updatedJsonData,
       version: 0,
       ...(state.token ? { secureJsonData: { token: state.token } } : {}),
     };

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -99,6 +99,28 @@
       ]
     }
   ],
+  "includes": [
+    {
+      "type": "dashboard",
+      "name": "Kentik: Home",
+      "path": "dashboards/kentik-home.json"
+    },
+    {
+      "type": "dashboard",
+      "name": "Kentik Top Talkers",
+      "path": "dashboards/kentik-top-talkers.json"
+    },
+    {
+      "type": "dashboard",
+      "name": "Kentik: Network Health & Traffic Overview",
+      "path": "dashboards/kentik-osi-health.json"
+    },
+    {
+      "type": "dashboard",
+      "name": "Kentik: Site & Device Overview",
+      "path": "dashboards/kentik-site-overview.json"
+    }
+  ],
   "dependencies": {
     "grafanaDependency": ">=11.6.0",
     "plugins": []

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,7 @@ export type JsonData = {
   region?: Region;
   dynamicUrl?: string;
   tokenSet?: boolean;
+  timeout?: number;
 };
 
 export interface MyDataSourceOptions extends JsonData, DataSourceJsonData {


### PR DESCRIPTION
Updates to allow for a longer timeout value. Improves success rate in larger data set queries. 