### PR TITLE
fix: dashboard includes + timeout state sync (v2.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 **Fixes:**
 
 - Increase proxy timeout from 30s to 1800s (30m) to prevent 502 errors on large Kentik accounts
+- Add dashboard `includes` to plugin.json so bundled dashboards appear on the datasource config page
+- Sync timeout field between server state and UI state in ConfigEditor
 
 ## 2.0.0 (2026-03-15)
 

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -141,7 +141,7 @@ export function ConfigEditor(props: Props) {
       region: state.region,
       dynamicUrl: state.dynamicUrl,
       tokenSet: !!state.token || state.tokenSet,
-      timeout: KENTIK_PROXY_TIMEOUT_SECONDS,
+      timeout: state.timeout,
     };
 
     // Build a minimal payload – only the fields the PUT endpoint needs.

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -147,12 +147,20 @@ export function ConfigEditor(props: Props) {
     // Build a minimal payload – only the fields the PUT endpoint needs.
     // Setting version to 0 tells Grafana to skip the optimistic-lock check,
     // which avoids 409 conflicts caused by provisioning version drift.
+    //
+    // timeout: Grafana's data proxy default is 30s, which is too short for
+    // large Kentik accounts. We set 1800s (30m) so queries against accounts
+    // with many devices/interfaces don't hit proxy timeouts.
+    const KENTIK_PROXY_TIMEOUT_SECONDS = 1800;
     const payload: Record<string, any> = {
       name: options.name,
       type: options.type,
       access: options.access,
       uid: options.uid,
-      jsonData: updatedJsonData,
+      jsonData: {
+        ...updatedJsonData,
+        timeout: KENTIK_PROXY_TIMEOUT_SECONDS,
+      },
       version: 0,
       ...(state.token ? { secureJsonData: { token: state.token } } : {}),
     };

--- a/src/ConfigEditor.tsx
+++ b/src/ConfigEditor.tsx
@@ -147,20 +147,12 @@ export function ConfigEditor(props: Props) {
     // Build a minimal payload – only the fields the PUT endpoint needs.
     // Setting version to 0 tells Grafana to skip the optimistic-lock check,
     // which avoids 409 conflicts caused by provisioning version drift.
-    //
-    // timeout: Grafana's data proxy default is 30s, which is too short for
-    // large Kentik accounts. We set 1800s (30m) so queries against accounts
-    // with many devices/interfaces don't hit proxy timeouts.
-    const KENTIK_PROXY_TIMEOUT_SECONDS = 1800;
     const payload: Record<string, any> = {
       name: options.name,
       type: options.type,
       access: options.access,
       uid: options.uid,
-      jsonData: {
-        ...updatedJsonData,
-        timeout: KENTIK_PROXY_TIMEOUT_SECONDS,
-      },
+      jsonData: updatedJsonData,
       version: 0,
       ...(state.token ? { secureJsonData: { token: state.token } } : {}),
     };


### PR DESCRIPTION
## Follow-up fixes for v2.0.1

These two fixes were added to `fix/proxy-timeout` after PR #94 was merged.

### Changes

**1. Add dashboard includes to plugin.json** (`eeb87d2`)
The 4 dashboard JSON files were bundled in the zip but `plugin.json` had no `includes` section, so Grafana never made them available for import on the datasource config page.

Adds includes for:
- Kentik: Home
- Kentik Top Talkers
- Kentik: Network Health & Traffic Overview
- Kentik: Site & Device Overview

**2. Sync timeout in jsonData between PUT payload and UI state** (`5f7e1be`)
Addresses Copilot review feedback from PR #94: `timeout` was only added to the PUT payload but not to `updatedJsonData`, leaving the in-memory UI state out of sync with the server.

- Add `timeout` field to `JsonData` type
- Move `KENTIK_PROXY_TIMEOUT_SECONDS` to component scope
- Initialize `state.timeout` from saved jsonData
- Use same `updatedJsonData` object for both PUT and `onOptionsChange`

### Testing
- `npm run build` passes
- Plugin validator passes in strict mode