### PR TITLE
chore: update @grafana/plugin-e2e to 3.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Kentik for Grafana
 
-> **Upgrading from v1.7.0 (`kentik-connect-app`)?** v2.0.0 is published as a new plugin (`kentik-connect-datasource`) because Grafana requires datasource plugins to use the `-datasource` ID suffix, the two plugins can coexist on the same Grafana instance without conflict. Your existing v1.7.0 dashboards and configuration remain fully functional while you migrate at your own pace. See the [v2.0.0 release notes](docs/v2.0.0-release.md) for migration steps.
+> **Upgrading from v1.7.0 (`kentik-connect-app`)?** Update to
+> `kentik-connect-app` v1.8.0 — a bridge release that automatically
+> installs `kentik-connect-datasource` v2.0.x. Both plugins coexist
+> without conflict. See the
+> [Migration Guide](docs/migration-guide.md) for step-by-step
+> instructions and the
+> [v2.0.0 release notes](docs/v2.0.0-release.md) for what's new.
 
 The Kentik datasource plugin allows you to query the Kentik API and visualize network traffic data directly in Grafana. It leverages the **Kentik Network Observability Platform** to provide real-time, Internet-scale ingest and querying of network data including flow records (NetFlow, IPFIX, sFlow), BGP, GeoIP, and SNMP.
 
@@ -42,7 +48,7 @@ To enable the datasource:
 
 ## Development
 
-This project requires **Node.js v22** or higher and **Docker**.
+This project requires **Node.js v18** or higher and **Docker**.
 
 1.  **Install dependencies**:
 
@@ -72,35 +78,33 @@ This project requires **Node.js v22** or higher and **Docker**.
 
 ## Build
 
-To produce a development build:
+To produce a production build:
 
 ```bash
 npm run build
 ```
 
-### Signed Build
+### Release (Signed + Attested)
 
-To build, sign, and package the plugin for distribution, use the signing script. A **Grafana API key** is required:
+Releases are automated via GitHub Actions. Pushing a version tag
+triggers the
+[release workflow](.github/workflows/release.yml), which:
 
-```bash
-GRAFANA_API_KEY=<your-key> ./scripts/build-signed.sh
-```
-
-This produces `kentik-datasource-dev.zip`.
-
-To specify a version:
-
-```bash
-GRAFANA_API_KEY=<your-key> ./scripts/build-signed.sh --version 1.5.0
-```
-
-This produces `kentik-datasource-1.5.0.zip`.
-
-To restrict signing to a specific Grafana instance:
+1. Builds the plugin (`npm run build`)
+2. Signs it with `@grafana/sign-plugin`
+   (requires the `GRAFANA_ACCESS_POLICY_TOKEN` repository secret)
+3. Creates a provenance attestation via sigstore
+4. Publishes a draft GitHub release with the signed zip and checksums
 
 ```bash
-GRAFANA_API_KEY=<your-key> ./scripts/build-signed.sh --root-urls https://grafana-test.kentiklabs.com
+# Create a tag matching package.json version and push
+npm version patch   # or minor / major
+git push origin main --follow-tags
 ```
+
+After the workflow completes, publish the draft release on GitHub
+and submit the zip URL to the
+[Grafana plugin catalog](https://grafana.com/plugins).
 
 ## Useful links
 

--- a/docs/v2.0.0-release.md
+++ b/docs/v2.0.0-release.md
@@ -71,8 +71,8 @@ v2.0.0 plugin. There is no workaround.
 
 ### Plugin type changed
 
-v1.7.0 was an `app` plugin with ID `kentik-connect-datasource`.  
-v2.0.0 is a `datasource` plugin, also with ID `kentik-connect-datasource`.
+v1.7.0 was an `app` plugin with ID `kentik-connect-app`.  
+v2.0.0 is a `datasource` plugin with ID `kentik-connect-datasource`.
 
 The plugin ID is **unchanged** — v2.0.0 is an in-place upgrade of the existing
 catalog entry. Existing dashboards referencing `kentik-connect-datasource` as their
@@ -84,8 +84,29 @@ configuration page after upgrading.
 
 ### Side-by-side installation
 
-Because both versions share the same plugin ID (`kentik-connect-datasource`), only one
-can be active at a time. Grafana will use whichever version is installed.
+Because the plugin ID changed from `kentik-connect-app` to
+`kentik-connect-datasource`, both plugins can coexist on the same
+Grafana instance. Existing v1.7.0 dashboards remain functional
+while you migrate panels to the new datasource.
+
+### Migration via v1.8.0 bridge
+
+`kentik-connect-app` v1.8.0 is a bridge release that declares a
+dependency on `kentik-connect-datasource`. When existing users
+update `kentik-connect-app`, Grafana automatically installs the
+new datasource plugin. See the
+[Migration Guide](migration-guide.md) for details.
+
+### v2.0.1 patch
+
+v2.0.1 fixes three issues found after the v2.0.0 release:
+
+- Proxy timeout increased from 30 s to 1800 s (30 min) to prevent
+  502 errors on large Kentik accounts
+- Dashboard `includes` added to `plugin.json` so bundled dashboards
+  appear on the datasource config page
+- Timeout field synced between server state and UI state in
+  ConfigEditor
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kentik-datasource",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kentik-datasource",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@grafana/eslint-config": "^9.0.0",
-        "@grafana/plugin-e2e": "^3.4.8",
+        "@grafana/plugin-e2e": "^3.5.0",
         "@grafana/tsconfig": "^2.0.1",
         "@playwright/test": "^1.52.0",
         "@stylistic/eslint-plugin-ts": "^2.9.0",
@@ -66,7 +66,7 @@
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1378,13 +1378,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.4.8.tgz",
-      "integrity": "sha512-HymTDWhbnzwXAvnYrET9SXypV6yjFV/lNe3CL1orCora7ZoGnxuX0q8aIAb1g6bAd7WidkZkH9V5CDxCMzBO2Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.5.0.tgz",
+      "integrity": "sha512-shKCFuvsgfo6wooP+kl8tUcg87motGkS+sD/s5taVEznHOCD5PVpyitWc+RboilyEZn6zfqcxwFHfbZhGO1eTw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.0.0-23251034887",
+        "@grafana/e2e-selectors": "13.1.0-24335230309",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@grafana/plugin-e2e/node_modules/@grafana/e2e-selectors": {
-      "version": "13.0.0-23251034887",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.0.0-23251034887.tgz",
-      "integrity": "sha512-wMY9N0iPySlKYId2nTQUkyoQscNIPGLi6zqFxbpZCAieNMrrNkHEJGP5m8FtPunpWjNc7WYeDGhDlY23qxMjeQ==",
+      "version": "13.1.0-24335230309",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24335230309.tgz",
+      "integrity": "sha512-EHd8S/MHBQFAlSVFvdG45sHu6iXIVSGN9szk8yAbJMnjqo90iKde9iErz2Qh4FCQCSv8M5zL3TUSeqlUDrrXGg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.4.8",
+    "@grafana/plugin-e2e": "^3.5.0",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "^1.52.0",
     "@stylistic/eslint-plugin-ts": "^2.9.0",

--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ The plugin provides instant access to the **Kentik Data Engine (KDE)**, enabling
 
 ## Requirements
 
-- A Grafana instance (v10.4 or later)
+- A Grafana instance (v11.6 or later)
 - An active **Kentik account** with API access
 - Devices registered in the Kentik portal
 

--- a/src/components/AppConfig.tsx
+++ b/src/components/AppConfig.tsx
@@ -1,0 +1,365 @@
+import { SecretInput } from './utils/SecretInput';
+import { showCustomAlert } from '../utils/alert_helper';
+import { KentikAPI } from '../datasource/kentik_api';
+
+import { Button, Field, Input, useStyles2, FieldSet, RadioButtonGroup } from '@grafana/ui';
+import { PluginConfigPageProps, AppPluginMeta, PluginMeta, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
+
+import { css } from '@emotion/css';
+
+import React, { useState, ChangeEvent, useEffect } from 'react';
+
+import * as _ from 'lodash';
+
+enum Region {
+  DEFAULT = 'default',
+  EU = 'eu',
+  CUSTOM = 'custom',
+}
+
+const REGION_OPTIONS: Array<SelectableValue<Region>> = [
+  {
+    label: 'US (default)',
+    value: Region.DEFAULT,
+  },
+  {
+    label: 'EU',
+    value: Region.EU,
+  },
+  {
+    label: 'Custom',
+    value: Region.CUSTOM,
+  },
+];
+
+export type JsonData = {
+  url?: string;
+  email?: string;
+  region?: Region;
+  dynamicUrl?: string;
+  tokenSet?: boolean;
+};
+
+type State = Required<JsonData> & {
+  apiValidated: boolean;
+  apiMemberWarning: boolean;
+  apiError: boolean;
+  // secretJsonData:
+  token: string;
+};
+
+interface Props extends PluginConfigPageProps<AppPluginMeta<JsonData>> {}
+
+export const AppConfig = ({ plugin }: Props) => {
+  const s = useStyles2(getStyles);
+  const { jsonData, enabled } = plugin.meta;
+
+  const [state, setState] = useState<State>({
+    url: jsonData?.url || 'https://grafana-api.kentik.com/api/v5',
+    email: jsonData?.email || '',
+    region: jsonData?.region || Region.DEFAULT,
+    dynamicUrl: jsonData?.dynamicUrl || '',
+    tokenSet: Boolean(jsonData?.tokenSet),
+    token: '',
+    apiValidated: false,
+    apiMemberWarning: false,
+    apiError: false,
+  });
+
+  const isConfigured = (): boolean => {
+    return (state.tokenSet || !_.isEmpty(state.token)) && !_.isEmpty(state.region) && !_.isEmpty(state.email);
+  };
+
+  const _onApiError = (): void => {
+    setState({
+      ...state,
+      apiValidated: false,
+      apiError: true,
+    });
+  };
+
+  const validateApiConnection = async (): Promise<boolean> => {
+    const backendSrv = getBackendSrv();
+    const kentik = new KentikAPI(backendSrv);
+    try {
+      await kentik.getSites();
+    } catch (e) {
+      _onApiError();
+      return false;
+    }
+
+    try {
+      await kentik.getUsers();
+    } catch (e: any) {
+      if (e.status !== 403) {
+        _onApiError();
+        return false;
+      }
+
+      setState({
+        ...state,
+        apiMemberWarning: true,
+      });
+    }
+
+    setState({
+      ...state,
+      apiValidated: true,
+    });
+    showCustomAlert('API working!', '', 'success');
+    return true;
+  };
+
+  useEffect(() => {
+    if (enabled && isConfigured()) {
+      // Validate async — the setState calls inside are in the async callback, not the effect body
+      const validate = async () => {
+        await validateApiConnection();
+      };
+      validate();
+    }
+    // eslint-disable-next-line
+  }, []);
+
+  const onResetToken = () =>
+    setState({
+      ...state,
+      token: '',
+      tokenSet: false,
+      apiValidated: false,
+      apiMemberWarning: false,
+      apiError: false,
+    });
+
+  const onChangeToken = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({
+      ...state,
+      token: event.target.value.trim(),
+    });
+  };
+
+  const onChangeEmail = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({
+      ...state,
+      email: event.target.value.trim(),
+    });
+  };
+
+  const onChangeCustomUrl = (event: ChangeEvent<HTMLInputElement>) => {
+    setState({
+      ...state,
+      dynamicUrl: event.target.value.trim(),
+      url: _getUrlByRegion(Region.CUSTOM),
+    });
+  };
+
+  const onChangeRegion = (region: Region) => {
+    setState({
+      ...state,
+      region,
+      url: _getUrlByRegion(region),
+      dynamicUrl: '',
+    });
+  };
+
+  const _getUrlByRegion = (region?: Region): string => {
+    switch (region) {
+      case Region.DEFAULT:
+        return 'https://grafana-api.kentik.com/api/v5';
+      case Region.EU:
+        return 'https://api.kentik.eu/api/v5';
+      case Region.CUSTOM:
+        return state.dynamicUrl;
+      default:
+        throw new Error(`Unknown region type: "${region}"`);
+    }
+  };
+
+  const updatePluginAndReload = async (pluginId: string, data: Partial<PluginMeta<JsonData>>) => {
+    try {
+      await updatePlugin(pluginId, { ...data, enabled: true, pinned: true });
+      await initDatasource(data);
+      // Reloading the page as the changes made here wouldn't be propagated to the actual plugin otherwise.
+      // This is not ideal, however unfortunately currently there is no supported way for updating the plugin state.
+      window.location.reload();
+    } catch (e) {
+      console.error('Error while updating the plugin', e);
+    }
+  };
+
+  const initDatasource = async (data: Partial<PluginMeta<JsonData>>): Promise<any[]> => {
+    const backendSrv = getBackendSrv();
+    //check for existing datasource.
+    const results = await backendSrv.get('/api/datasources');
+    let foundKentikDS = false;
+    let updateKentikDS = false;
+    let dsID = NaN;
+    _.forEach(results, (ds) => {
+      // use the type
+      if (ds.type === 'kentik-connect-datasource' || ds.type === 'kentik-ds') {
+        foundKentikDS = true;
+        dsID = ds.id;
+        updateKentikDS = true;
+
+        if (ds.type === 'kentik-ds' || ds.jsonData.region !== data.jsonData?.region || ds.jsonData !== data.jsonData) {
+          updateKentikDS = true;
+        }
+        return;
+      }
+    });
+    const promisesResults: any[] = [];
+    if (!foundKentikDS || updateKentikDS) {
+      // create datasource
+      const datasourceSettings = {
+        name: 'kentik',
+        type: 'kentik-connect-datasource',
+        access: 'proxy',
+        jsonData: data.jsonData,
+      };
+      if (updateKentikDS) {
+        // update requires a PUT with the id
+        promisesResults.push(await backendSrv.put(`/api/datasources/${dsID}`, datasourceSettings));
+      } else {
+        promisesResults.push(await backendSrv.post('/api/datasources', datasourceSettings));
+      }
+    }
+    return promisesResults;
+  };
+
+  return (
+    <div>
+      {/* CUSTOM SETTINGS */}
+      <FieldSet label="Enter your Kentik Credentials" className={s.marginTop}>
+        {/* Email */}
+        <Field label="Email" description="">
+          <Input
+            width={60}
+            id="email"
+            label={`Email`}
+            value={state.email}
+            placeholder={`email`}
+            onChange={onChangeEmail}
+          />
+        </Field>
+
+        {/* Region */}
+        <Field label="Region" description="">
+          <RadioButtonGroup value={state.region} options={REGION_OPTIONS} onChange={onChangeRegion} />
+        </Field>
+
+        {/* Custom URL */}
+        {state.region === Region.CUSTOM && (
+          <Field label="Custom URL" description="">
+            <Input
+              width={60}
+              id="custom-url"
+              label={`Custom URL`}
+              value={state.dynamicUrl}
+              placeholder={`https://grafana-api.kentik.com/api/v5`}
+              onChange={onChangeCustomUrl}
+            />
+          </Field>
+        )}
+
+        {/* API Token */}
+        <Field label="API Token">
+          <SecretInput
+            width={60}
+            id="api-token"
+            value={state.token}
+            isConfigured={state.tokenSet}
+            placeholder={'Your secret API token'}
+            onChange={onChangeToken}
+            onReset={onResetToken}
+          />
+        </Field>
+
+        {isConfigured() && state.apiError && (
+          <div className={s.errorBox}>
+            <i className={`fa fa-exclamation-circle ${s.colorError}`}>
+              <span className={s.marginLeft}>
+                Invalid API credentials. This app won`t work until the credentials are updated.
+              </span>
+            </i>
+          </div>
+        )}
+
+        {state.tokenSet && state.apiValidated && (
+          <div className="kentik-enabled-box">
+            <i className="icon-gf icon-gf-check kentik-api-status-icon success"></i>
+            <span className={s.marginLeft}>
+              Successfully enabled.
+              <strong> Next up: </strong>
+              <a href="d/xScUGST71/kentik-home" className="external-link">
+                Go to Kentik Home Dashboard
+              </a>
+            </span>
+          </div>
+        )}
+
+        {state.tokenSet && state.apiValidated && state.apiMemberWarning && (
+          <div className="kentik-enabled-box">
+            <i className="fa fa-warning kentik-api-status-icon warning"></i>
+            <span className={s.marginLeft}>
+              The specified Kentik user seems to have Member access level (not Admin), Custom Dimensions in the
+              dashboard filters won`t be available.
+            </span>
+          </div>
+        )}
+
+        <div className={s.marginTop}>
+          <Button
+            type="submit"
+            onClick={() =>
+              updatePluginAndReload(plugin.meta.id, {
+                jsonData: {
+                  tokenSet: true,
+                  url: state.url,
+                  email: state.email,
+                  region: state.region,
+                  dynamicUrl: state.dynamicUrl,
+                },
+                // This cannot be queried later by the frontend.
+                // We don't want to override it in case it was set previously and left untouched now.
+                secureJsonData: state.tokenSet
+                  ? undefined
+                  : {
+                      token: state.token,
+                    },
+              })
+            }
+            disabled={!isConfigured()}
+          >
+            Save API settings
+          </Button>
+        </div>
+      </FieldSet>
+    </div>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  colorError: css`
+    color: ${theme.colors.error.text};
+  `,
+  marginTop: css`
+    margin-top: ${theme.spacing(1)};
+  `,
+  marginLeft: css`
+    margin-left: ${theme.spacing(1)};
+  `,
+  errorBox: css`
+    display: flex;
+    align-items: center;
+    margin: ${theme.spacing(1)} 0;
+  `,
+});
+
+const updatePlugin = async (pluginId: string, data: Partial<PluginMeta>): Promise<void> => {
+  await (getBackendSrv() as any).post(
+    `/api/plugins/${pluginId}/settings`,
+    data,
+    { showSuccessAlert: false }
+  );
+};


### PR DESCRIPTION
Updates `@grafana/plugin-e2e` from 3.4.12 → 3.5.0.

Fixes the panelEditPage E2E test failures where `DashboardPage.addPanel()` timed out waiting for `[data-testid="data-testid Add button"]`. The 3.5.0 release uses version-aware selectors (`PageToolbar.item("Add panel")`) that work across Grafana 11.6–12.x.

**CI will validate this** — the E2E tests that were failing should now pass.