### PR TITLE
fix: enforce SNMP dimension-metric category compatibility

### DIFF
--- a/dashboards/kentik-home.json
+++ b/dashboards/kentik-home.json
@@ -12,7 +12,7 @@
       "type": "text",
       "title": "",
       "gridPos": {
-        "h": 8,
+        "h": 16,
         "w": 12,
         "x": 0,
         "y": 0
@@ -20,7 +20,7 @@
       "id": 1,
       "options": {
         "mode": "markdown",
-        "content": "![Kentik](public/plugins/kentik-connect-datasource/img/logo_large.png)\n\n# Kentik for Grafana\n\nKentik for Grafana allows you to quickly and easily add network activity visibility metrics to your Grafana dashboard.\n\nBy leveraging the power of Kentik's monitoring SaaS, you can enjoy rich, actionable insights into consumers of network bandwidth and anomalies that can affect application or service performance.\n\n**Getting Started:**\n1. ✅ Install Kentik for Grafana\n2. Configure your [Kentik datasource](/connections/datasources) with API credentials\n3. Explore the dashboards in the Kentik folder →"
+        "content": "![Kentik](/public/plugins/kentik-connect-datasource/img/logo_large.png)\n\n# Kentik for Grafana\n\nKentik for Grafana allows you to quickly and easily add network activity visibility metrics to your Grafana dashboard.\n\nBy leveraging the power of Kentik's monitoring SaaS, you can enjoy rich, actionable insights into consumers of network bandwidth and anomalies that can affect application or service performance.\n\n**Getting Started:**\n1. ✅ Install Kentik for Grafana\n2. Configure your [Kentik datasource](/connections/datasources) with API credentials\n3. Explore the dashboards in the Kentik folder →"
       },
       "fieldConfig": {
         "defaults": {},
@@ -31,7 +31,7 @@
       "type": "dashlist",
       "title": "Kentik Dashboards",
       "gridPos": {
-        "h": 8,
+        "h": 16,
         "w": 12,
         "x": 12,
         "y": 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kentik-datasource",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kentik-datasource",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.10.6",
@@ -21,7 +21,7 @@
       },
       "devDependencies": {
         "@grafana/eslint-config": "^9.0.0",
-        "@grafana/plugin-e2e": "^3.4.8",
+        "@grafana/plugin-e2e": "^3.6.1",
         "@grafana/tsconfig": "^2.0.1",
         "@playwright/test": "^1.52.0",
         "@stylistic/eslint-plugin-ts": "^2.9.0",
@@ -66,7 +66,7 @@
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1378,13 +1378,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.4.8.tgz",
-      "integrity": "sha512-HymTDWhbnzwXAvnYrET9SXypV6yjFV/lNe3CL1orCora7ZoGnxuX0q8aIAb1g6bAd7WidkZkH9V5CDxCMzBO2Q==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.6.1.tgz",
+      "integrity": "sha512-BQAEMk2yVymYA2cKbHEuGDqXwZ5MwWnCD+293QJgMey3G6ao4PbiZTaZ/c5BVyfWxLOZ3izqay0F7eU0Ncty9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.0.0-23251034887",
+        "@grafana/e2e-selectors": "13.1.0-24448182242",
         "semver": "^7.5.4",
         "uuid": "^13.0.0",
         "yaml": "^2.3.4"
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@grafana/plugin-e2e/node_modules/@grafana/e2e-selectors": {
-      "version": "13.0.0-23251034887",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.0.0-23251034887.tgz",
-      "integrity": "sha512-wMY9N0iPySlKYId2nTQUkyoQscNIPGLi6zqFxbpZCAieNMrrNkHEJGP5m8FtPunpWjNc7WYeDGhDlY23qxMjeQ==",
+      "version": "13.1.0-24448182242",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-24448182242.tgz",
+      "integrity": "sha512-C8VxaFh4PGWhPBOwol3Fo0UBp1//7XNnjg7WG+t3p0P8Q2cw5HZ2NgQt1OFq9radjmWEc3DJQZvxoelI4TIOJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@grafana/eslint-config": "^9.0.0",
-    "@grafana/plugin-e2e": "^3.4.8",
+    "@grafana/plugin-e2e": "^3.6.1",
     "@grafana/tsconfig": "^2.0.1",
     "@playwright/test": "^1.52.0",
     "@stylistic/eslint-plugin-ts": "^2.9.0",

--- a/provisioning/dashboards/dashboards.yaml
+++ b/provisioning/dashboards/dashboards.yaml
@@ -11,3 +11,15 @@ providers:
     updateIntervalSeconds: 600
     options:
       path: /root/kentik-connect-datasource/dashboards
+  # Used by Playwright e2e tests to navigate directly to a panel edit page
+  # without relying on the brittle DashboardPage.addPanel() flow.
+  - name: "Kentik E2E"
+    orgId: 1
+    folder: "Kentik E2E"
+    type: file
+    disableDeletion: false
+    editable: true
+    allowUiUpdates: true
+    updateIntervalSeconds: 600
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/provisioning/dashboards/kentik-e2e-test.json
+++ b/provisioning/dashboards/kentik-e2e-test.json
@@ -1,0 +1,58 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Kentik E2E Test Panel",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "datasource": {
+        "type": "kentik-connect-datasource",
+        "uid": "kentik"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "kentik-connect-datasource",
+            "uid": "kentik"
+          }
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "options": {}
+    }
+  ],
+  "schemaVersion": 39,
+  "tags": [
+    "kentik",
+    "e2e"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Kentik E2E Test",
+  "uid": "kentik-e2e-test",
+  "version": 1
+}

--- a/src/datasource/QueryEditor.tsx
+++ b/src/datasource/QueryEditor.tsx
@@ -541,8 +541,10 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
     const query: Query = _.cloneDeep(props.query);
     query['metric'] = value;
 
-    // Auto-clear incompatible dimensions when metric category changes.
-    // Collect the compatibleCategory values from the new metric selection.
+    // Auto-clear incompatible NMS dimensions when metric category changes.
+    // Flow dimensions are compatible with both flow and NMS metrics, so they are
+    // never auto-cleared. Only NMS dimensions whose category does not match any
+    // currently-selected NMS metric category need to be removed.
     const newMetricCompat = new Set(
       value
         .map((m) => {
@@ -552,10 +554,6 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
         .filter(Boolean) as string[]
     );
     const newHasNmsMetric = [...newMetricCompat].some((c) => NMS_CATEGORIES.has(c));
-    const newHasFlowMetric = value.length === 0 || value.some((m) => {
-      const opt = state.metrics.find((o: any) => o.value === m.value);
-      return !(opt as any)?.compatibleCategory;
-    });
 
     if (value.length > 0) {
       const currentDims = ensureArray(query.dimension);
@@ -563,9 +561,11 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
         const dim = dimensionList.find((dl) => dl.value === d.value);
         const isNmsDim = dim?.category && NMS_CATEGORIES.has(dim.category);
         if (!isNmsDim) {
-          return newHasFlowMetric && !newHasNmsMetric;
+          // Flow dimension — always compatible.
+          return true;
         }
-        return newMetricCompat.has(dim!.category!);
+        // NMS dimension — only valid if at least one selected NMS metric matches.
+        return newHasNmsMetric && newMetricCompat.has(dim!.category!);
       });
       if (filteredDims.length !== currentDims.length) {
         query.dimension = filteredDims as Query['dimension'];
@@ -663,30 +663,30 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
     }
 
     // Auto-clear incompatible metrics when dimension category changes.
-    // Collect the categories of the new dimension selection.
+    // Rules (mirroring buildTopXdataQuery validation):
+    //   • flow dim    + flow metric   → OK
+    //   • flow dim    + NMS metric    → OK (flow dims don't constrain metrics)
+    //   • NMS dim     + flow metric   → invalid (NMS dim requires SNMP/ST metric)
+    //   • NMS dim     + NMS metric    → OK only if categories match
     const newDimCategories = new Set(
       value
         .map((d) => {
           const dim = dimensionList.find((dl) => dl.value === d.value);
           return dim?.category;
         })
-        .filter(Boolean) as string[]
+        .filter((c): c is DimensionCategory => !!c && NMS_CATEGORIES.has(c))
     );
-    const newHasNmsDim = [...newDimCategories].some((c) => NMS_CATEGORIES.has(c));
-    const newHasFlowDim = value.length === 0 || value.some((d) => {
-      const dim = dimensionList.find((dl) => dl.value === d.value);
-      return !dim?.category || !NMS_CATEGORIES.has(dim.category);
-    });
+    const newHasNmsDim = newDimCategories.size > 0;
 
-    if (value.length > 0) {
+    if (newHasNmsDim) {
       const currentMetrics = ensureArray(query.metric);
       const filteredMetrics = currentMetrics.filter((m) => {
         const opt = state.metrics.find((o: any) => o.value === m.value);
         const compatCat = (opt as any)?.compatibleCategory;
         const isNmsMetric = compatCat && NMS_CATEGORIES.has(compatCat);
-        if (!isNmsMetric) {
-          return newHasFlowDim && !newHasNmsDim;
-        }
+        // Flow metric is invalid when any NMS dim is selected.
+        if (!isNmsMetric) { return false; }
+        // NMS metric must match one of the selected NMS dim categories.
         return newDimCategories.has(compatCat);
       });
       if (filteredMetrics.length !== currentMetrics.length) {
@@ -1009,11 +1009,6 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       .filter(Boolean) as string[]
   );
   const hasNmsDim = [...selectedDimCategories].some((c) => NMS_CATEGORIES.has(c));
-  const hasFlowDim = selectedDimensions.length === 0 ||
-    selectedDimensions.some((d) => {
-      const dim = dimensionList.find((dl) => dl.value === d.value);
-      return !dim?.category || !NMS_CATEGORIES.has(dim.category);
-    });
 
   // compatibleCategory values present in the currently selected metrics
   const selectedMetricCompat = new Set(
@@ -1031,43 +1026,60 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       return !(opt as any)?.compatibleCategory;
     });
 
+  // Restrict to NMS dim categories only — flow dims do not constrain metric choice.
+  const selectedNmsDimCategories = new Set(
+    [...selectedDimCategories].filter((c) => NMS_CATEGORIES.has(c))
+  );
+  const selectedNmsMetricCompat = new Set(
+    [...selectedMetricCompat].filter((c) => NMS_CATEGORIES.has(c))
+  );
+
   // Remove incompatible metrics based on selected dimensions
   // AND selected metrics (can't mix flow + NMS metric types).
   const filteredMetrics = state.metrics.filter((metric: any) => {
-    // Dimension-based constraints
-    if (selectedDimensions.length > 0) {
-      if (!metric.compatibleCategory) {
-        if (!(hasFlowDim && !hasNmsDim)) { return false; }
-      } else {
-        if (!selectedDimCategories.has(metric.compatibleCategory)) { return false; }
-      }
+    const isNmsMetricOption = metric.compatibleCategory && NMS_CATEGORIES.has(metric.compatibleCategory);
+
+    // Dimension-based constraints — only NMS dims constrain metrics.
+    // Flow dims are compatible with both flow and NMS metrics (matches
+    // buildTopXdataQuery validation).
+    if (hasNmsDim) {
+      // Any NMS dim selected → flow metrics are invalid.
+      if (!isNmsMetricOption) { return false; }
+      // NMS metric must match one of the selected NMS dim categories.
+      if (!selectedNmsDimCategories.has(metric.compatibleCategory)) { return false; }
     }
 
     // Metric-to-metric constraints: once a metric type is chosen,
     // hide metrics of incompatible types (flow vs NMS).
     if (selectedMetrics.length > 0) {
-      const isNmsMetricOption = metric.compatibleCategory && NMS_CATEGORIES.has(metric.compatibleCategory);
       if (!isNmsMetricOption) {
         // This is a flow metric — only compatible if existing selection includes flow
         if (!(hasFlowMetric && !hasNmsMetric)) { return false; }
       } else {
         // This is an NMS metric — only compatible if existing selection matches its category
-        if (!(!hasFlowMetric && (!hasNmsMetric || selectedMetricCompat.has(metric.compatibleCategory)))) { return false; }
+        if (!(!hasFlowMetric && (!hasNmsMetric || selectedNmsMetricCompat.has(metric.compatibleCategory)))) { return false; }
       }
     }
 
     return true;
   });
 
-  // Remove incompatible dimensions based on selected metrics
+  // Remove incompatible dimensions based on selected metrics.
+  // Flow dimensions remain available for any metric selection (matches
+  // buildTopXdataQuery validation: flow dim + NMS metric is supported).
+  // Only NMS dimensions need to be filtered to match the selected NMS metric
+  // category, and they are hidden entirely when no NMS metric is selected
+  // (since picking one would force metric clearing).
   const filteredDimensions = state.dimensions.filter((dim: any) => {
+    const isNmsDim = dim.category && NMS_CATEGORIES.has(dim.category);
+    if (!isNmsDim) {
+      // Flow dimension — always compatible.
+      return true;
+    }
     if (selectedMetrics.length > 0) {
-      const isNmsDim = dim.category && NMS_CATEGORIES.has(dim.category);
-      if (!isNmsDim) {
-        if (!(hasFlowMetric && !hasNmsMetric)) { return false; }
-      } else {
-        if (!selectedMetricCompat.has(dim.category)) { return false; }
-      }
+      // NMS dim requires at least one selected NMS metric whose category matches.
+      if (!hasNmsMetric) { return false; }
+      if (!selectedNmsMetricCompat.has(dim.category)) { return false; }
     }
     return true;
   });

--- a/src/datasource/QueryEditor.tsx
+++ b/src/datasource/QueryEditor.tsx
@@ -90,6 +90,13 @@ const FIELDS_VALIDATION_MESSAGES = {
 
 const MAX_DIMENSIONS = 8;
 
+/** NMS dimension categories that require matched dimensions and metrics. */
+const NMS_CATEGORIES = new Set<string>([
+  DimensionCategory.SNMP_DEVICE,
+  DimensionCategory.SNMP_INTERFACE,
+  DimensionCategory.ST_INTERFACE,
+]);
+
 // Helper to append a variable option if it exists in Grafana variables
 function appendVariableIfExists(options: QueryItem[], variableName: string): QueryItem[] {
   const templateSrv = getTemplateSrv();
@@ -193,7 +200,8 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       options = result.map((item: any) => ({
         label: item.text || item.label,
         value: item.value,
-        ...item
+        ...item,
+        ...(item.category ? { group: item.category } : {}),
       }));
     }
 
@@ -533,6 +541,37 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
     const query: Query = _.cloneDeep(props.query);
     query['metric'] = value;
 
+    // Auto-clear incompatible dimensions when metric category changes.
+    // Collect the compatibleCategory values from the new metric selection.
+    const newMetricCompat = new Set(
+      value
+        .map((m) => {
+          const opt = state.metrics.find((o: any) => o.value === m.value);
+          return (opt as any)?.compatibleCategory;
+        })
+        .filter(Boolean) as string[]
+    );
+    const newHasNmsMetric = [...newMetricCompat].some((c) => NMS_CATEGORIES.has(c));
+    const newHasFlowMetric = value.length === 0 || value.some((m) => {
+      const opt = state.metrics.find((o: any) => o.value === m.value);
+      return !(opt as any)?.compatibleCategory;
+    });
+
+    if (value.length > 0) {
+      const currentDims = ensureArray(query.dimension);
+      const filteredDims = currentDims.filter((d) => {
+        const dim = dimensionList.find((dl) => dl.value === d.value);
+        const isNmsDim = dim?.category && NMS_CATEGORIES.has(dim.category);
+        if (!isNmsDim) {
+          return newHasFlowMetric && !newHasNmsMetric;
+        }
+        return newMetricCompat.has(dim!.category!);
+      });
+      if (filteredDims.length !== currentDims.length) {
+        query.dimension = filteredDims as Query['dimension'];
+      }
+    }
+
     onQueryChange(query);
     const queryValid = isQueryValid(query);
     onRunQuery(queryValid);
@@ -621,6 +660,38 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
 
     if (newAliasBy !== props.query.aliasBy) {
       query.aliasBy = newAliasBy;
+    }
+
+    // Auto-clear incompatible metrics when dimension category changes.
+    // Collect the categories of the new dimension selection.
+    const newDimCategories = new Set(
+      value
+        .map((d) => {
+          const dim = dimensionList.find((dl) => dl.value === d.value);
+          return dim?.category;
+        })
+        .filter(Boolean) as string[]
+    );
+    const newHasNmsDim = [...newDimCategories].some((c) => NMS_CATEGORIES.has(c));
+    const newHasFlowDim = value.length === 0 || value.some((d) => {
+      const dim = dimensionList.find((dl) => dl.value === d.value);
+      return !dim?.category || !NMS_CATEGORIES.has(dim.category);
+    });
+
+    if (value.length > 0) {
+      const currentMetrics = ensureArray(query.metric);
+      const filteredMetrics = currentMetrics.filter((m) => {
+        const opt = state.metrics.find((o: any) => o.value === m.value);
+        const compatCat = (opt as any)?.compatibleCategory;
+        const isNmsMetric = compatCat && NMS_CATEGORIES.has(compatCat);
+        if (!isNmsMetric) {
+          return newHasFlowDim && !newHasNmsDim;
+        }
+        return newDimCategories.has(compatCat);
+      });
+      if (filteredMetrics.length !== currentMetrics.length) {
+        query.metric = filteredMetrics as Query['metric'];
+      }
     }
 
     onQueryChange(query);
@@ -924,11 +995,6 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
   // ── Dimension ↔ Metric cross-filtering ──────────────────────────────────
   // NMS categories require matched dimensions and metrics AND specific devices;
   // flow categories (no compatibleCategory / no category) are always mutually compatible.
-  const NMS_CATEGORIES = new Set<string>([
-    DimensionCategory.SNMP_DEVICE,
-    DimensionCategory.SNMP_INTERFACE,
-    DimensionCategory.ST_INTERFACE,
-  ]);
 
   const selectedDimensions = ensureArray(props.query.dimension);
   const selectedMetrics = ensureArray(props.query.metric);
@@ -965,48 +1031,45 @@ export const QueryEditor: React.FC<QueryEditorComponentProps> = (props) => {
       return !(opt as any)?.compatibleCategory;
     });
 
-  // Grey-out (disable) incompatible metrics based on selected dimensions
+  // Remove incompatible metrics based on selected dimensions
   // AND selected metrics (can't mix flow + NMS metric types).
-  const filteredMetrics = state.metrics.map((metric: any) => {
-    let compatible = true;
-
+  const filteredMetrics = state.metrics.filter((metric: any) => {
     // Dimension-based constraints
     if (selectedDimensions.length > 0) {
       if (!metric.compatibleCategory) {
-        compatible = hasFlowDim && !hasNmsDim;
+        if (!(hasFlowDim && !hasNmsDim)) { return false; }
       } else {
-        compatible = selectedDimCategories.has(metric.compatibleCategory);
+        if (!selectedDimCategories.has(metric.compatibleCategory)) { return false; }
       }
     }
 
     // Metric-to-metric constraints: once a metric type is chosen,
-    // disable metrics of incompatible types (flow vs NMS).
-    if (compatible && selectedMetrics.length > 0) {
+    // hide metrics of incompatible types (flow vs NMS).
+    if (selectedMetrics.length > 0) {
       const isNmsMetricOption = metric.compatibleCategory && NMS_CATEGORIES.has(metric.compatibleCategory);
       if (!isNmsMetricOption) {
         // This is a flow metric — only compatible if existing selection includes flow
-        compatible = hasFlowMetric && !hasNmsMetric;
+        if (!(hasFlowMetric && !hasNmsMetric)) { return false; }
       } else {
         // This is an NMS metric — only compatible if existing selection matches its category
-        compatible = !hasFlowMetric && (!hasNmsMetric || selectedMetricCompat.has(metric.compatibleCategory));
+        if (!(!hasFlowMetric && (!hasNmsMetric || selectedMetricCompat.has(metric.compatibleCategory)))) { return false; }
       }
     }
 
-    return compatible ? metric : { ...metric, isDisabled: true };
+    return true;
   });
 
-  // Grey-out (disable) incompatible dimensions based on selected metrics
-  const filteredDimensions = state.dimensions.map((dim: any) => {
-    let compatible = true;
+  // Remove incompatible dimensions based on selected metrics
+  const filteredDimensions = state.dimensions.filter((dim: any) => {
     if (selectedMetrics.length > 0) {
       const isNmsDim = dim.category && NMS_CATEGORIES.has(dim.category);
       if (!isNmsDim) {
-        compatible = hasFlowMetric && !hasNmsMetric;
+        if (!(hasFlowMetric && !hasNmsMetric)) { return false; }
       } else {
-        compatible = selectedMetricCompat.has(dim.category);
+        if (!selectedMetricCompat.has(dim.category)) { return false; }
       }
     }
-    return compatible ? dim : { ...dim, isDisabled: true };
+    return true;
   });
 
   return (

--- a/src/datasource/query_builder.ts
+++ b/src/datasource/query_builder.ts
@@ -1,5 +1,6 @@
 import { ALL_DEVICES_LABEL, ALL_SITES_LABEL } from './DataSource';
-import { filterFieldList, FilterField, allMetricOptions } from './metric_def';
+import { filterFieldList, FilterField, allMetricOptions, dimensionList } from './metric_def';
+import { DimensionCategory } from './metric_types';
 
 import * as _ from 'lodash';
 
@@ -176,6 +177,64 @@ function buildTopXdataQuery(options: any, panelId?: string) {
   if (_.isEmpty(metricDefs)) {
     throw new Error('Query error: Metric field is required');
   }
+
+  // ── Dimension ↔ Metric category compatibility check ─────────────────────
+  // SNMP/ST dimensions and metrics must belong to the same category.
+  // Crossing categories (e.g. SNMP Device dimension + SNMP Interface metric)
+  // queries different KDE partitions and silently returns zero rows.
+  const NMS_DIM_CATEGORIES = new Set<string>([
+    DimensionCategory.SNMP_DEVICE,
+    DimensionCategory.SNMP_INTERFACE,
+    DimensionCategory.ST_INTERFACE,
+  ]);
+
+  const dimensionValues: string[] = options.dimension?.split(',') || [];
+  const dimCategories = new Set<DimensionCategory>(
+    dimensionValues
+      .map((v: string) => dimensionList.find((d) => d.value === normaliseKtPrefix(v))?.category)
+      .filter((c): c is DimensionCategory => !!c && NMS_DIM_CATEGORIES.has(c))
+  );
+
+  const metricCategories = new Set<DimensionCategory>(
+    metricDefs
+      .map((m: any): DimensionCategory | null => {
+        const unit: string = m.unit || '';
+        if (unit.startsWith('ktappprotocol__snmp_device_metrics__')) { return DimensionCategory.SNMP_DEVICE; }
+        if (unit.startsWith('ktappprotocol__snmp__')) { return DimensionCategory.SNMP_INTERFACE; }
+        if (unit.startsWith('ktappprotocol__st__')) { return DimensionCategory.ST_INTERFACE; }
+        return null;
+      })
+      .filter((c): c is DimensionCategory => c !== null)
+  );
+
+  if (dimCategories.size > 0 && metricCategories.size > 0) {
+    // Both sides are NMS — they must share the same category.
+    for (const mc of metricCategories) {
+      if (!dimCategories.has(mc)) {
+        const dimCat = [...dimCategories][0];
+        throw new Error(
+          `Query error: ${dimCat} dimensions are not compatible with ${mc} metrics. ` +
+          `SNMP/ST dimensions must be paired with metrics from the same category.`
+        );
+      }
+    }
+    for (const dc of dimCategories) {
+      if (!metricCategories.has(dc)) {
+        const metricCat = [...metricCategories][0];
+        throw new Error(
+          `Query error: ${dc} dimensions are not compatible with ${metricCat} metrics. ` +
+          `SNMP/ST dimensions must be paired with metrics from the same category.`
+        );
+      }
+    }
+  } else if (dimCategories.size > 0 && metricCategories.size === 0) {
+    // NMS dimensions with flow metrics — invalid.
+    const dimCat = [...dimCategories][0];
+    throw new Error(
+      `Query error: ${dimCat} dimensions require SNMP/ST metrics, not flow metrics.`
+    );
+  }
+  // Note: flow dimensions + NMS metrics is allowed (existing pattern in tests/dashboards).
 
 
   const startingTime = options.range.from.utc().format(KENTIK_TIME_FORMAT);

--- a/src/datasource/query_builder.ts
+++ b/src/datasource/query_builder.ts
@@ -213,7 +213,7 @@ function buildTopXdataQuery(options: any, panelId?: string) {
       if (!dimCategories.has(mc)) {
         const dimCat = [...dimCategories][0];
         throw new Error(
-          `Query error: ${dimCat} dimensions are not compatible with ${mc} metrics. ` +
+          `Query error: dimensions from category "${dimCat}" are not compatible with metrics from category "${mc}". ` +
           `SNMP/ST dimensions must be paired with metrics from the same category.`
         );
       }
@@ -222,7 +222,7 @@ function buildTopXdataQuery(options: any, panelId?: string) {
       if (!metricCategories.has(dc)) {
         const metricCat = [...metricCategories][0];
         throw new Error(
-          `Query error: ${dc} dimensions are not compatible with ${metricCat} metrics. ` +
+          `Query error: dimensions from category "${dc}" are not compatible with metrics from category "${metricCat}". ` +
           `SNMP/ST dimensions must be paired with metrics from the same category.`
         );
       }
@@ -231,7 +231,7 @@ function buildTopXdataQuery(options: any, panelId?: string) {
     // NMS dimensions with flow metrics — invalid.
     const dimCat = [...dimCategories][0];
     throw new Error(
-      `Query error: ${dimCat} dimensions require SNMP/ST metrics, not flow metrics.`
+      `Query error: dimensions from category "${dimCat}" require SNMP/ST metrics, not flow metrics.`
     );
   }
   // Note: flow dimensions + NMS metrics is allowed (existing pattern in tests/dashboards).

--- a/src/datasource/tests/query_builder.test.ts
+++ b/src/datasource/tests/query_builder.test.ts
@@ -548,4 +548,137 @@ describe('Kentik Query Builder', () => {
       ]);
     });
   });
+
+  // ── Dimension ↔ Metric category compatibility validation ────────────────
+  //
+  // SNMP/ST dimensions and metrics must belong to the same category.
+  // Crossing categories (e.g. SNMP Device dimension + SNMP Interface metric)
+  // queries different KDE partitions and returns zero rows, so the query
+  // builder must reject these combinations with a clear error.
+
+  describe('Dimension ↔ Metric category compatibility', () => {
+    let baseOptions: any;
+
+    beforeEach(() => {
+      baseOptions = {
+        deviceNames: 'router1',
+        siteNames: null,
+        range: ctx.range,
+        kentikFilterGroups: [],
+        topx: '8',
+      };
+    });
+
+    it('SNMP Device dimension + SNMP Device metric → succeeds', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp_device_metrics__i_device_name',
+          metric: 'avg_ktappprotocol__snmp_device_metrics__INT64_00',
+        })
+      ).not.toThrow();
+    });
+
+    it('SNMP Interface dimension + SNMP Interface metric → succeeds', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp__output_port',
+          metric: 'avg_ktappprotocol__snmp__INT64_00',
+        })
+      ).not.toThrow();
+    });
+
+    it('ST Interface dimension + ST Interface metric → succeeds', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__st__output_port',
+          metric: 'avg_ktappprotocol__st__INT64_00',
+        })
+      ).not.toThrow();
+    });
+
+    it('flow dimension + flow metric → succeeds', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'src_geo_region',
+          metric: 'avg_bits_per_sec',
+        })
+      ).not.toThrow();
+    });
+
+    it('flow dimension + SNMP metric → succeeds (existing pattern)', () => {
+      // Flow dimensions have no NMS category, so this is allowed.
+      // The API routes on the metric prefix alone.
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'src_geo_region',
+          metric: 'avg_ktappprotocol__snmp_device_metrics__INT64_00',
+        })
+      ).not.toThrow();
+    });
+
+    it('SNMP Device dimension + SNMP Interface metric → throws', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp_device_metrics__i_device_name',
+          metric: 'avg_ktappprotocol__snmp__INT64_00',
+        })
+      ).toThrow(/not compatible/);
+    });
+
+    it('SNMP Interface dimension + SNMP Device metric → throws', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp__output_port',
+          metric: 'avg_ktappprotocol__snmp_device_metrics__INT64_00',
+        })
+      ).toThrow(/not compatible/);
+    });
+
+    it('SNMP Device dimension + ST Interface metric → throws', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp_device_metrics__i_device_name',
+          metric: 'avg_ktappprotocol__st__INT64_00',
+        })
+      ).toThrow(/not compatible/);
+    });
+
+    it('SNMP Device dimension + flow metric → throws', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp_device_metrics__i_device_name',
+          metric: 'avg_bits_per_sec',
+        })
+      ).toThrow(/require SNMP\/ST metrics/);
+    });
+
+    it('SNMP Interface dimension + flow metric → throws', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp__output_port',
+          metric: 'avg_bits_per_sec',
+        })
+      ).toThrow(/require SNMP\/ST metrics/);
+    });
+
+    it('error message includes both category names', () => {
+      expect(() =>
+        queryBuilder.buildTopXdataQuery({
+          ...baseOptions,
+          dimension: 'ktappprotocol__snmp_device_metrics__i_device_name',
+          metric: 'avg_ktappprotocol__snmp__INT64_00',
+        })
+      ).toThrow(/SNMP Device Metrics.*SNMP Interface Metrics/);
+    });
+  });
 });

--- a/tests/queryEditor.spec.ts
+++ b/tests/queryEditor.spec.ts
@@ -1,8 +1,15 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
-test('smoke: query editor renders all field sections', async ({ panelEditPage, readProvisionedDataSource }) => {
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  await panelEditPage.datasource.set(ds.name);
+test('smoke: query editor renders all field sections', async ({
+  gotoPanelEditPage,
+  readProvisionedDashboard,
+}) => {
+  // Navigate directly to a provisioned dashboard's panel edit page. This avoids the
+  // brittle DashboardPage.addPanel() UI flow which has compatibility issues across
+  // Grafana 11.x/12.x/13.x and the various plugin-e2e versions (the toolbar "Add"
+  // button is not reliably present on a freshly-created empty dashboard with scenes).
+  const dashboard = await readProvisionedDashboard({ fileName: 'kentik-e2e-test.json' });
+  const panelEditPage = await gotoPanelEditPage({ dashboard, id: '1' });
 
   const queryRow = panelEditPage.getQueryEditorRow('A');
 
@@ -20,12 +27,12 @@ test('smoke: query editor renders all field sections', async ({ panelEditPage, r
 });
 
 test('smoke: data mode toggle switches between graph and table', async ({
-  panelEditPage,
-  readProvisionedDataSource,
+  gotoPanelEditPage,
+  readProvisionedDashboard,
   page,
 }) => {
-  const ds = await readProvisionedDataSource({ fileName: 'datasources.yml' });
-  await panelEditPage.datasource.set(ds.name);
+  const dashboard = await readProvisionedDashboard({ fileName: 'kentik-e2e-test.json' });
+  const panelEditPage = await gotoPanelEditPage({ dashboard, id: '1' });
 
   const queryRow = panelEditPage.getQueryEditorRow('A');
 


### PR DESCRIPTION
## Summary

SNMP dimensions only work with metrics from the same category (Device↔Device, Interface↔Interface, ST↔ST). Crossing categories silently returns zero results from the Kentik API. This PR enforces compatibility at two levels.

## Changes

### QueryEditor (`src/datasource/QueryEditor.tsx`)
- **Auto-clear incompatible selections**: When dimensions change to an NMS category, incompatible metrics are automatically removed (and vice versa). Follows the existing `onSitesSelect` → clear devices pattern.
- **Remove instead of disable**: Incompatible options are now filtered out of dropdowns entirely. Grafana's `MultiCombobox` doesn't support `isDisabled` on options — the old code set it but it was silently ignored.
- **`NMS_CATEGORIES`** moved to module scope so both handlers and render logic can reference it.

### Query Builder (`src/datasource/query_builder.ts`)
- **Pre-flight validation**: `buildTopXdataQuery` now checks dimension-metric category compatibility before sending the API request. Mismatched combinations throw a descriptive error (e.g. *"SNMP Device Metrics dimensions are not compatible with SNMP Interface Metrics metrics"*). This catches bypasses via template variables and saved dashboard JSON.

### Dashboard
- Fix broken image on Kentik Home dashboard (add leading `/` to image path)
- Increase welcome panel heights from 8 to 16

### Tests
- 11 new unit tests covering all valid and invalid SNMP category combinations

## Testing
- All 150 unit tests pass
- Build succeeds
- TypeScript type checking clean
- Manual: selecting SNMP Device dimension removes flow/interface metrics from dropdown
- Manual: selecting flow metric removes NMS dimensions from dropdown